### PR TITLE
Docker image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,11 @@
+FROM condaforge/miniforge3:latest
+
+ARG QUETZ_VERSION=0.0.4
+
+RUN conda install -q -y quetz==${QUETZ_VERSION} && \
+    conda clean --all -f -y
+ENV LANG=en_US.UTF-8
+
+USER nobody
+# TODO: use the CLI when available in the next release to set-up Quetz
+CMD ["/bin/bash"]


### PR DESCRIPTION
Description
---
Create a `docker` image to use `Quetz`. 
Containerization is a different way to use an application, see #44 .

I also created a repo for `Quetz` under the `TheSnakePit` organization on DockerHub.
- If it's OK, I will transfer the ownership to QuantStack members
- If not, I will delete it

TODOs
---

- [ ] Update the package requirement in `Dockerfile` to use the CLI
- [ ] Transfer the ownership of the [TheSnakePit DockerHub org](https://hub.docker.com/r/thesnakepit/quetz) to @wolfv or other `QuantStack` members
- [ ] Add GitHub action(s) for building the image and publishing it. Maybe it implies a pipeline to build the conda package and publishing it on conda-forge if the Dockerfile relies on a conda package installation
Discussion
---
Base `Quetz` and `Boa` images on `Mamba` image to be released.