### PR TITLE
Onboarding create api keys

### DIFF
--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -137,11 +137,14 @@ class Rules:
                     role.package,
                     required_package_role,
                 )
-            else:
+            elif role.channel:
                 required_channel_roles = (
                     [OWNER] if role.role == OWNER else [OWNER, MAINTAINER]
                 )
                 self.assert_channel_roles(role.channel, required_channel_roles)
+            else:
+                # create key without assigning special channel/package privilages
+                return True
 
     def assert_upload_file(self, channel_name, package_name):
         self.assert_channel_or_package_roles(

--- a/quetz/basic_frontend/index.html
+++ b/quetz/basic_frontend/index.html
@@ -10,6 +10,7 @@
 <a href="/auth/google/login" style="margin-right: 100px" id="google_login">login with google</a>
 <a href="/auth/github/revoke" style="margin-right: 100px" id="revoke">revoke github</a>
 <a href="/auth/google/revoke" style="margin-right: 100px" id="revoke">revoke google</a>
+<button type="submit" onclick="getApiKey()">Get API key</button>
 <a href="/auth/logout" id="logout">logout</a>
 <div id="status"></div>
 
@@ -18,6 +19,20 @@
     const status = document.getElementById('status');
 
     getProfile();
+
+    function getApiKey() {
+      fetch('/api/api-keys', {
+        method: 'POST',
+        body: JSON.stringify({"description": "default key", "roles":[]}),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+            .then(response => {console.log(response.status); return response.json()})
+      .then(data => {
+          status.innerHTML = `API key: <pre>${data.key}</pre>`;
+      });
+    }
 
     function getProfile() {
         fetch('/api/me')

--- a/quetz/basic_frontend/index.html
+++ b/quetz/basic_frontend/index.html
@@ -3,6 +3,48 @@
 <head>
     <meta charset="UTF-8">
     <title>Quetz</title>
+    <style>
+    .modal {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        opacity: 0;
+        visibility: hidden;
+        transform: scale(1.1);
+        transition: visibility 0s linear 0.25s, opacity 0.25s 0s, transform 0.25s;
+    }
+    .modal-content {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background-color: white;
+        padding: 1rem 1.5rem;
+        width: 24rem;
+        border-radius: 0.5rem;
+    }
+    .close-button {
+        float: right;
+        width: 1.5rem;
+        line-height: 1.5rem;
+        text-align: center;
+        cursor: pointer;
+        border-radius: 0.25rem;
+        background-color: lightgray;
+    }
+    .close-button:hover {
+        background-color: darkgray;
+    }
+    .show-modal {
+        opacity: 1;
+        visibility: visible;
+        transform: scale(1.0);
+        transition: visibility 0s linear 0s, opacity 0.25s 0s, transform 0.25s;
+    }
+    </style>
 </head>
 <body>
 <h1>Quetz</h1>
@@ -10,7 +52,13 @@
 <a href="/auth/google/login" style="margin-right: 100px" id="google_login">login with google</a>
 <a href="/auth/github/revoke" style="margin-right: 100px" id="revoke">revoke github</a>
 <a href="/auth/google/revoke" style="margin-right: 100px" id="revoke">revoke google</a>
-<button type="submit" onclick="getApiKey()">Get API key</button>
+
+<div class="modal">
+  <div class="modal-content">
+    <span class="close-button">&times;</span>
+    <div id="modalmsg">Hello, I am a modal!</div>
+  </div>
+</div>
 <a href="/auth/logout" id="logout">logout</a>
 <div id="status"></div>
 
@@ -19,6 +67,25 @@
     const status = document.getElementById('status');
 
     getProfile();
+
+    var modal = document.querySelector(".modal");
+    var trigger = document.querySelector(".trigger");
+    var closeButton = document.querySelector(".close-button");
+    const modalmsg = document.getElementById('modalmsg');
+
+
+    function toggleModal() {
+        modal.classList.toggle("show-modal");
+    }
+
+    function windowOnClick(event) {
+        if (event.target === modal) {
+            toggleModal();
+        }
+    }
+
+    closeButton.addEventListener("click", toggleModal);
+    window.addEventListener("click", windowOnClick);
 
     function getApiKey() {
       fetch('/api/api-keys', {
@@ -30,7 +97,8 @@
       })
             .then(response => {console.log(response.status); return response.json()})
       .then(data => {
-          status.innerHTML = `API key: <pre>${data.key}</pre>`;
+          modalmsg.innerHTML = `API key: <pre>${data.key}</pre>`;
+          toggleModal();
       });
     }
 
@@ -49,7 +117,7 @@
             })
             .then(data => {
                 var name = data.name || data.user.username;
-                status.innerHTML = `<h2>Welcome ${name}</h2><img height="50px" src="${data.avatar_url}"/><br><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                status.innerHTML = `<h2>Welcome ${name}</h2><img height="50px" src="${data.avatar_url}"/><br><pre>${JSON.stringify(data, null, 2)}</pre><br><button type="submit" onclick="getApiKey()">Get API key</button>`;
             });
     }
 

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -46,7 +46,7 @@ def _fill_test_database(db: Session) -> NoReturn:
 
     testUsers = []
     try:
-        for index, username in enumerate(['alice', 'bob', 'carol', 'dave', 'btel']):
+        for index, username in enumerate(['alice', 'bob', 'carol', 'dave']):
             user = User(id=uuid.uuid4().bytes, username=username)
 
             identity = Identity(

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -46,7 +46,7 @@ def _fill_test_database(db: Session) -> NoReturn:
 
     testUsers = []
     try:
-        for index, username in enumerate(['alice', 'bob', 'carol', 'dave']):
+        for index, username in enumerate(['alice', 'bob', 'carol', 'dave', 'btel']):
             user = User(id=uuid.uuid4().bytes, username=username)
 
             identity = Identity(

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -52,7 +52,12 @@ class ConfigSection(NamedTuple):
 class Config:
     _config_map = (
         ConfigSection(
-            "github", [ConfigEntry("client_id", str), ConfigEntry("client_secret", str)]
+            "github",
+            [
+                ConfigEntry("client_id", str),
+                ConfigEntry("client_secret", str),
+                ConfigEntry("privilaged_users", list, default=[]),
+            ],
         ),
         ConfigSection("sqlalchemy", [ConfigEntry("database_url", str)]),
         ConfigSection(

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -56,7 +56,6 @@ class Config:
             [
                 ConfigEntry("client_id", str),
                 ConfigEntry("client_secret", str),
-                ConfigEntry("privilaged_users", list, default=[]),
             ],
         ),
         ConfigSection("sqlalchemy", [ConfigEntry("database_url", str)]),

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -98,6 +98,7 @@ class Dao:
             description=data.description,
             mirror_channel_url=data.mirror_channel_url,
             mirror_mode=data.mirror_mode,
+            private=data.private,
         )
 
         member = ChannelMember(channel=channel, user_id=user_id, role=role)

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -295,6 +295,8 @@ class Dao:
 
         self.db.commit()
 
+        return db_api_key
+
     def create_version(
         self,
         channel_name,

--- a/quetz/dao_github.py
+++ b/quetz/dao_github.py
@@ -9,7 +9,12 @@ from .db_models import Identity, Profile, User
 
 
 def create_user_with_github_identity(db: Session, github_profile) -> User:
-    user = User(id=uuid.uuid4().bytes, username=github_profile['login'])
+
+    # retrieve user if already exists
+    user = db.query(User).filter_by(username=github_profile['login']).first()
+
+    if not user:
+        user = User(id=uuid.uuid4().bytes, username=github_profile['login'])
 
     identity = Identity(
         provider='github',
@@ -53,7 +58,7 @@ def update_user_from_github_profile(db: Session, user, identity, profile) -> Use
 def get_user_by_github_identity(db: Session, profile) -> User:
     user, identity = db.query(User, Identity).join(Identity).filter(
         Identity.provider == 'github'
-    ).filter(Identity.identity_id == profile['id']).one_or_none() or (None, None)
+    ).filter(Identity.identity_id == str(profile['id'])).one_or_none() or (None, None)
 
     if user:
         if user_github_profile_changed(user, identity, profile):

--- a/quetz/dao_github.py
+++ b/quetz/dao_github.py
@@ -10,11 +10,7 @@ from .db_models import Identity, Profile, User
 
 def create_user_with_github_identity(db: Session, github_profile) -> User:
 
-    # retrieve user if already exists
-    user = db.query(User).filter_by(username=github_profile['login']).first()
-
-    if not user:
-        user = User(id=uuid.uuid4().bytes, username=github_profile['login'])
+    user = User(id=uuid.uuid4().bytes, username=github_profile['login'])
 
     identity = Identity(
         provider='github',

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -453,13 +453,6 @@ def get_channel_members(
     dao: Dao = Depends(get_dao),
 ):
     member_list = dao.get_channel_members(channel.name)
-    for member in member_list:
-        # force loading of profile before changing attributes to prevent sqlalchemy
-        # errors.
-        # TODO: don't abuse db models for this.
-
-        member.user.profile
-        # setattr(member.user, "id", str(uuid.UUID(bytes=member.user.id)))
 
     return member_list
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -459,7 +459,7 @@ def get_channel_members(
         # TODO: don't abuse db models for this.
 
         member.user.profile
-        setattr(member.user, "id", str(uuid.UUID(bytes=member.user.id)))
+        # setattr(member.user, "id", str(uuid.UUID(bytes=member.user.id)))
 
     return member_list
 
@@ -606,7 +606,9 @@ def get_api_keys(
     ]
 
 
-@api_router.post("/api-keys", status_code=201, tags=["API keys"])
+@api_router.post(
+    "/api-keys", status_code=201, tags=["API keys"], response_model=rest_models.ApiKey
+)
 def post_api_key(
     api_key: rest_models.BaseApiKey,
     dao: Dao = Depends(get_dao),
@@ -619,6 +621,10 @@ def post_api_key(
 
     key = secrets.token_urlsafe(32)
     dao.create_api_key(user_id, api_key, key)
+
+    return rest_models.ApiKey(
+        description=api_key.description, roles=api_key.roles, key=key
+    )
 
 
 @api_router.post(

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Generic, List, Optional, TypeVar
 
@@ -25,7 +26,7 @@ class Profile(BaseProfile):
 
 
 class BaseUser(BaseModel):
-    id: str
+    id: uuid.UUID
     username: str
 
     class Config:

--- a/quetz/tests/test_auth.py
+++ b/quetz/tests/test_auth.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import uuid
+from unittest import mock
 
 from pytest import fixture
 
@@ -20,7 +21,11 @@ class Data:
         Profile(name='userb', user=self.userb, avatar_url='')
         db.add(self.userb)
 
-        assert len(db.query(User).all()) == 2
+        self.userc = User(id=uuid.uuid4().bytes, username='userc')
+        Profile(name='userc', user=self.userc, avatar_url='')
+        db.add(self.userc)
+
+        assert len(db.query(User).all()) == 3
 
         db.add(ApiKey(key=self.keya, user_id=self.usera.id, owner_id=self.usera.id))
         db.add(ApiKey(key=self.keyb, user_id=self.userb.id, owner_id=self.userb.id))
@@ -34,10 +39,14 @@ class Data:
         self.channel_member = ChannelMember(
             channel=self.channel2, user=self.usera, role='member'
         )
+        self.channel_member_userc = ChannelMember(
+            channel=self.channel2, user=self.userc, role='owner'
+        )
         for el in [
             self.channel1,
             self.channel2,
             self.channel_member,
+            self.channel_member_userc,
             self.package1,
             self.package2,
         ]:
@@ -161,7 +170,7 @@ def test_private_channels(data, client):
         f'/api/channels/{data.channel2.name}/members', headers={"X-Api-Key": data.keya}
     )
     assert response.status_code == 200
-    assert len(response.json()) == 1
+    assert len(response.json()) == 2
     assert ('role', data.channel_member.role) in response.json()[0].items()
     assert response.json()[0]['user']['id'] == str(uuid.UUID(bytes=data.usera.id))
 
@@ -349,3 +358,34 @@ def test_private_channels_download(db, client, data, channel_dirs):
     )
     assert response.status_code == 200
     assert response.text == "file content 1"
+
+
+def test_create_api_key(data, client):
+
+    response = client.get(f"/api/dummylogin/{data.userc.username}")
+    assert response.status_code == 200
+
+    response = client.post(
+        '/api/api-keys',
+        json={
+            "description": "test-key",
+            "roles": [{"channel": "privatechannel", "role": "member"}],
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "description": "test-key",
+        "roles": [{"channel": "privatechannel", "role": "member", "package": None}],
+        "key": mock.ANY,
+    }
+
+    # get key without special privilages
+
+    response = client.post(
+        '/api/api-keys',
+        json={"description": "test-key", "roles": []},
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {"description": "test-key", "roles": [], "key": mock.ANY}

--- a/quetz/tests/test_github_dao.py
+++ b/quetz/tests/test_github_dao.py
@@ -1,0 +1,12 @@
+from quetz import dao_github
+
+
+def test_get_user_by_github_identity_new_user(db):
+
+    profile = {"id": 4567, "login": "bartosz", "name": "bartosz", "avatar_url": "url"}
+
+    user = dao_github.get_user_by_github_identity(db, profile)
+
+    assert user.username == 'bartosz'
+    assert user.identities[0].provider == 'github'
+    assert user.identities[0].identity_id == '4567'


### PR DESCRIPTION
a few fixes to streamline onboarding new users:

* allow create api keys without special privilages, this key is valid for example to post (create) new channels
* return the new key after it is created with the POST /api/api-keys method
* add a button in basic fronted to retrieve and display the key in a modal window
* also some more tests and fixes 

Notes:
* POST /api/api-keys plays two roles: creating new keys and assigning permissions, the permissions are not specific to the key but for all keys of the user
* there is no role of superadmin who by default has read/write access to all channels/packages/users