### PR TITLE
Remove roles from api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,12 @@ client_secret = "EXAMPLESECRETmD-7UXVCMZV3C7b-kZ9yf70"
 
 ## PostgreSQL
 
-By default, quetz will run with sqlite database, which works well for local tests and small local instances. However, if you plan to run quetz in production, we recommend to configure it with the PostgreSQL database. There are several options to install PostgreSQL server on your local machine or production server, one of them being the official PostgreSQL docker image. You can pull it from the docker hub and start the server with the commands:
+By default, quetz will run with sqlite database, which works well for local tests and small local instances. However, if you plan to run quetz in production, we recommend to configure it with the PostgreSQL database. There are several options to install PostgreSQL server on your local machine or production server, one of them being the official PostgreSQL docker image. 
+
+
+### Running PostgreSQL server with docker
+
+You can the PostgresSQL image from the docker hub and start the server with the commands:
 
 ```
 docker pull postgres
@@ -168,6 +173,8 @@ You can then create a database in PostgreSQL for quetz tables:
 sudo -u postgres psql -h localhost -c 'CREATE DATABASE quetz OWNER postgres;'
 ```
 
+###  Deploying Quetz with PostgreSQL backend
+
 Then in your configuration file (such as `dev_config.toml`) replace the `[sqlalchemy]` section with:
 
 ```
@@ -177,11 +184,28 @@ database_url = "postgresql://postgres:mysecretpassword@localhost:5432/quetz"
 
 Finally, you can create and run a new quetz deployment based on this configuration (we assume that you saved it in file `config_postgres.yml`):
 
+
 ```
 quetz run postgres_quetz --copy-conf config_postgres.toml 
 ```
 
 Note that this recipe will create an ephemeral PostgreSQL database and it will delete all data after the `some-postgres` container is stopped and removed. To make the data persistent, please check the documentation of the `postgres` [image](https://hub.docker.com/_/postgres/)  or your container orchestration system (Kubernetes or similar).
+
+### Running tests with PostgreSQL backend
+
+To run the tests with the PostgreSQL database instead of the default SQLite, follow the steps [above](#running-postgresql-server-with-docker) to start the PG server. Then create an new database:
+
+```
+psql -U postgres -h localhost -c 'CREATE DATABASE test_quetz OWNER postgres;'
+```
+
+You will be asked to type the password to the DB, which you defined when starting your PG server. In the docker-based instructions above, we set it to `mysecretpassword`.
+
+To run the tests with this database you need to configure the `QUETZ_TEST_DATABASE` environment variable:
+
+```
+QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@localhost:5432/test_quetz" pytest -v ./quetz/tests
+```
 
 ## Frontend
 

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -253,65 +253,19 @@ class Dao:
         self.db.add(member)
         self.db.commit()
 
-    def get_package_api_keys(self, user_id):
-        return (
-            self.db.query(PackageMember, ApiKey)
-            .join(User, PackageMember.user_id == User.id)
-            .join(ApiKey, ApiKey.user_id == User.id)
-            .filter(ApiKey.owner_id == user_id)
-            .all()
-        )
-
-    def get_channel_api_keys(self, user_id):
-        return (
-            self.db.query(ChannelMember, ApiKey)
-            .join(User, ChannelMember.user_id == User.id)
-            .join(ApiKey, ApiKey.user_id == User.id)
-            .filter(ApiKey.owner_id == user_id)
-            .all()
-        )
+    def get_api_keys(self, user_id):
+        return self.db.query(ApiKey).filter(ApiKey.owner_id == user_id).all()
 
     def create_api_key(self, user_id, api_key: rest_models.BaseApiKey, key):
         owner = self.get_user(user_id)
-        # for now users can create key only for themselves
+
+        # users are also owners
         user = owner
         db_api_key = ApiKey(
             key=key, description=api_key.description, user=user, owner=owner
         )
 
         self.db.add(db_api_key)
-        for role in api_key.roles:
-            if role.package:
-                package_member = (
-                    self.db.query(PackageMember)
-                    .filter_by(
-                        user=user, channel_name=role.channel, package_name=role.package
-                    )
-                    .one_or_none()
-                )
-                if not package_member:
-                    package_member = PackageMember(
-                        user=user,
-                        channel_name=role.channel,
-                        package_name=role.package,
-                        role=role.role,
-                    )
-                    self.db.add(package_member)
-                else:
-                    package_member.role = role.role
-            else:
-                channel_member = (
-                    self.db.query(ChannelMember)
-                    .filter_by(user=user, channel_name=role.channel)
-                    .one_or_none()
-                )
-                if not channel_member:
-                    channel_member = ChannelMember(
-                        user=user, channel_name=role.channel, role=role.role
-                    )
-                    self.db.add(channel_member)
-                else:
-                    channel_member.role = role.role
 
         self.db.commit()
 

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -117,7 +117,6 @@ class CPRole(BaseModel):
 
 class BaseApiKey(BaseModel):
     description: str
-    roles: List[CPRole]
 
 
 class ApiKey(BaseApiKey):


### PR DESCRIPTION
these roles are redundant with the `channels/{}/members` and `packages/{}/members` endpoints.  we plan to add a proper support for scopes in the future  `"api:read", "api:write"`, etc.)