### PR TITLE
fix s3 storage interface to work with other providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You should have [mamba](https://github.com/mamba-org/mamba) or conda installed.
 Then create an environment:
 
 ```
-mamba create -n quetz -c conda-forge 'python>=3.7' fastapi typer authlib httpx=0.12.0 sqlalchemy sqlite \
+mamba create -n quetz -c conda-forge 'python>=3.7' fastapi typer authlib=0.14.3 httpx=0.12.0 sqlalchemy sqlite \
 python-multipart uvicorn zstandard conda-build appdirs toml quetz-client fsspec "h2<4.0.0"
 
 conda activate quetz
@@ -125,11 +125,12 @@ Then add your access and secret keys to the `s3` section with your
 access_key = "AKIAIOSFODNN7EXAMPLE"
 secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 url = "https://..."
+region = ""
 bucket_prefix="..."
 bucket_suffix="..."
 ```
 
-Be sure to set the url field if not using AWS.
+Be sure to set the url and region field if not using AWS.
 
 Channels are created with the following semantics:
 ```

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -69,6 +69,7 @@ class Config:
                 ConfigEntry("access_key", str, default=""),
                 ConfigEntry("secret_key", str, default=""),
                 ConfigEntry("url", str, default=""),
+                ConfigEntry("region", str, default=""),
                 ConfigEntry("bucket_prefix", str, default=""),
                 ConfigEntry("bucket_suffix", str, default=""),
             ],
@@ -196,6 +197,7 @@ class Config:
                     'key': self.s3_access_key,
                     'secret': self.s3_secret_key,
                     'url': self.s3_url,
+                    'region': self.s3_region,
                     'bucket_prefix': self.s3_bucket_prefix,
                     'bucket_suffix': self.s3_bucket_suffix,
                 }

--- a/quetz/dao_github.py
+++ b/quetz/dao_github.py
@@ -52,9 +52,15 @@ def update_user_from_github_profile(db: Session, user, identity, profile) -> Use
 
 
 def get_user_by_github_identity(db: Session, profile) -> User:
-    user, identity = db.query(User, Identity).join(Identity).filter(
-        Identity.provider == 'github'
-    ).filter(Identity.identity_id == str(profile['id'])).one_or_none() or (None, None)
+    try:
+        user, identity = db.query(User, Identity).join(Identity).filter(
+            Identity.provider == 'github'
+        ).filter(Identity.identity_id == str(profile['id'])).one_or_none() or (
+            None,
+            None,
+        )
+    except KeyError:
+        print(f"unexpected response format: {profile}")
 
     if user:
         if user_github_profile_changed(user, identity, profile):

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -94,8 +94,11 @@ class S3Store(PackageStore):
 
         client_kwargs = {}
         url = config.get('url')
+        region = config.get("region")
         if url:
             client_kwargs['endpoint_url'] = url
+        if region:
+            client_kwargs["region_name"] = region
 
         # When using IAM, key and secret will be empty, so need to pass None
         # to the s3fs constructor
@@ -126,7 +129,7 @@ class S3Store(PackageStore):
         """
         with self._get_fs() as fs:
             try:
-                fs.mkdir(self._bucket_map(name))
+                fs.mkdir(self._bucket_map(name), acl="private")
             except FileExistsError:
                 pass
 
@@ -134,7 +137,9 @@ class S3Store(PackageStore):
         with self._get_fs() as fs:
             bucket = self._bucket_map(channel)
             with fs.transaction:
-                with fs.open(path.join(bucket, destination), "wb") as pkg:
+                with fs.open(
+                    path.join(bucket, destination), "wb", acl="private"
+                ) as pkg:
                     shutil.copyfileobj(package, pkg)
 
     def add_file(
@@ -148,7 +153,7 @@ class S3Store(PackageStore):
         with self._get_fs() as fs:
             bucket = self._bucket_map(channel)
             with fs.transaction:
-                with fs.open(path.join(bucket, destination), mode) as f:
+                with fs.open(path.join(bucket, destination), mode, acl="private") as f:
                     f.write(data)
 
     def serve_path(self, channel, src):


### PR DESCRIPTION
tested with OVH,

sample parameters for OVH:

```
[s3]
access_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
secret_key = "f1f2f3f4f6f7f8f9f0a1a2a3a4a5a6a7a8"
url = "https://s3.sbg.cloud.ovh.net"
region = "sbg"
bucket_prefix="quetz-"
bucket_suffix=""
```

it also pins the authlib version because of the authlib bug: https://github.com/lepture/authlib/issues/283