### PR TITLE
adding loggers

### DIFF
--- a/dev_config.toml
+++ b/dev_config.toml
@@ -10,3 +10,7 @@ database_url = "sqlite:///./quetz.sqlite"
 # openssl rand -hex 32
 secret = "b72376b88e6f249cb0921052ea8a092381ca17fd8bb0caf4d847e337b3d34cf8"
 https_only = false
+
+[logging]
+level = "DEBUG"
+file = "quetz.log"

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -1,6 +1,7 @@
 # Copyright 2020 QuantStack
 # Distributed under the terms of the Modified BSD License.
 
+import logging
 import os
 from base64 import b64encode
 from distutils.util import strtobool
@@ -254,6 +255,34 @@ def create_config(
         config = ''.join(f.readlines())
 
     return config.format(client_id, client_secret, database_url, secret, https)
+
+
+def configure_logger(level=None):
+    """Get quetz logger"""
+
+    if not level:
+        log_level = os.environ.get("QUETZ_LOG_LEVEL", "INFO")
+        level = getattr(logging, log_level.upper())
+
+    # create logger with 'quetz'
+    logger = logging.getLogger('quetz')
+    logger.setLevel(level)
+    ch = logging.StreamHandler()
+
+    try:
+        from uvicorn.logging import ColourizedFormatter
+
+        formatter = ColourizedFormatter(
+            fmt="%(levelprefix)s [%(name)s] %(asctime)s %(message)s", use_colors=True
+        )
+    except ImportError:
+        formatter = logging.Formatter('%(levelname)s %(name)s  %(asctime)s %(message)s')
+    ch.setFormatter(formatter)
+
+    # add the handlers to the logger
+    logger.addHandler(ch)
+
+    return logger
 
 
 def get_plugin_manager() -> pluggy.PluginManager:

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -82,6 +82,14 @@ class Config:
             [ConfigEntry("client_id", str), ConfigEntry("client_secret", str)],
             required=False,
         ),
+        ConfigSection(
+            "logging",
+            [
+                ConfigEntry("level", str, default="INFO"),
+                ConfigEntry("file", str, default=""),
+            ],
+            required=False,
+        ),
     )
     _config_dirs = [_site_dir, _user_dir]
     _config_files = [os.path.join(d, _filename) for d in _config_dirs]
@@ -257,12 +265,19 @@ def create_config(
     return config.format(client_id, client_secret, database_url, secret, https)
 
 
-def configure_logger(level=None):
+def configure_logger(config=None):
     """Get quetz logger"""
 
-    if not level:
-        log_level = os.environ.get("QUETZ_LOG_LEVEL", "INFO")
-        level = getattr(logging, log_level.upper())
+    if hasattr(config, "logging_level"):
+        log_level = config.logging_level
+    else:
+        log_level = "INFO"
+
+    log_level = os.environ.get("QUETZ_LOG_LEVEL", log_level)
+
+    level = getattr(logging, log_level.upper())
+
+    print(log_level)
 
     # create logger with 'quetz'
     logger = logging.getLogger('quetz')

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -273,11 +273,14 @@ def configure_logger(config=None):
     else:
         log_level = "INFO"
 
+    if hasattr(config, "logging_file"):
+        filename = config.logging_file
+    else:
+        filename = None
+
     log_level = os.environ.get("QUETZ_LOG_LEVEL", log_level)
 
     level = getattr(logging, log_level.upper())
-
-    print(log_level)
 
     # create logger with 'quetz'
     logger = logging.getLogger('quetz')
@@ -296,6 +299,12 @@ def configure_logger(config=None):
 
     # add the handlers to the logger
     logger.addHandler(ch)
+
+    if filename:
+        fh = logging.FileHandler(filename)
+        formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s  %(message)s')
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
 
     return logger
 

--- a/quetz/indexing.py
+++ b/quetz/indexing.py
@@ -4,6 +4,7 @@
 import bz2
 import hashlib
 import json
+import logging
 import numbers
 from datetime import datetime, timezone
 
@@ -23,6 +24,8 @@ _iec_prefixes = (
     (1024, "{:.0f} KiB"),
     (1, "{:.0f} B"),
 )
+
+logger = logging.getLogger("quetz")
 
 
 def _iec_bytes(n):
@@ -108,6 +111,7 @@ def update_indexes(dao, pkgstore, channel_name):
 
     subdir_template = jinjaenv.get_template("subdir-index.html.j2")
     for dir in subdirs:
+        logger.debug(f"creating indexes for subdir {dir} of channel {channel_name}")
         raw_repodata = repo_data.export(dao, channel_name, dir)
 
         repodata = json.dumps(raw_repodata, indent=2, sort_keys=True)

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 import datetime
 import json
+import logging
 import os
 import re
 import secrets
@@ -49,7 +50,9 @@ config = Config()
 auth_github.register(config)
 
 
-logger = configure_logger()
+configure_logger(config)
+
+logger = logging.getLogger("quetz")
 
 app.add_middleware(
     SessionMiddleware,

--- a/quetz/mirror.py
+++ b/quetz/mirror.py
@@ -281,7 +281,12 @@ def initial_sync_mirror(
                 logger.debug(f"updating package {package_name} form {arch}")
                 pass
 
-            remote_package = remote_repository.open(path)
+            try:
+                remote_package = remote_repository.open(path)
+            except RemoteServerError:
+                logger.error(f"remote server error when getting a file {path}")
+                continue
+
             files = [remote_package]
             try:
                 handle_package_files(


### PR DESCRIPTION
also fixes an issue with mirror synchronisation

to configure the log level use `'[logging]` section of the config or set `QUETZ_LOG_LEVEL` env variable:

`export QUETZ_LOG_LEVEL=debug`

quetz logging messages are duplicated due to uvicron bug:

https://github.com/encode/uvicorn/issues/630