### PR TITLE
add conda-suggest plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,6 @@ jobs:
           
           pip install ./plugins/quetz_repodata_patching
           pytest -v ./plugins/quetz_repodata_patching
+
+          pip install ./plugins/quetz_conda_suggest
+          pytest -v ./plugins/quetz_conda_suggest

--- a/plugins/quetz_conda_suggest/README.md
+++ b/plugins/quetz_conda_suggest/README.md
@@ -1,0 +1,12 @@
+# quetz_conda_suggest plugin
+
+This is a plugin to use with the [quetz](https://github.com/mamba-org/quetz) package server.
+
+
+## Installing
+
+To install use:
+
+```
+pip install .
+```

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
@@ -1,45 +1,29 @@
-import json
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm.session import Session
 
-from quetz.db_models import PackageVersion
 from quetz.deps import get_db
 
 router = APIRouter()
 
 
-@router.get("/api/channels/{channel_name}/conda-suggest")
-def get_conda_suggest(channel_name, db: Session = Depends(get_db)):
-    all_packages = (
-        db.query(PackageVersion)
-        .filter(PackageVersion.channel_name == channel_name)
-        .all()
+@router.get("/api/channels/{channel_name}/{subdir}/conda-suggest")
+def get_conda_suggest(channel_name, subdir, db: Session = Depends(get_db)):
+    map_filename = "{0}.{1}.map".format(channel_name, subdir)
+    map_filepath = os.path.join(
+        os.getcwd(), "channels", channel_name, subdir, map_filename
     )
 
-    channel_suggest_map = {}
-    error = False
-    for each_package in all_packages:
-        if not each_package.files:
-            error = True
-        else:
-            files_data = json.loads(each_package.files.data)
-            for (k, v) in files_data.items():
-                channel_suggest_map[k] = v
-
-    if error:
+    if os.path.isfile(map_filepath):
+        return FileResponse(
+            map_filepath,
+            media_type="application/octet-stream",
+            filename=map_filename,
+        )
+    else:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="files for all packages not found",
+            detail=f"conda-suggest map file for {channel_name}.{subdir} not found",
         )
-
-    with open("{0}.map".format(channel_name), "w") as f:
-        for (k, v) in sorted(channel_suggest_map.items()):
-            f.write("{0}:{1}\n".format(k, v))
-
-    return FileResponse(
-        "{0}.map".format(channel_name),
-        media_type="application/octet-stream",
-        filename="{0}.map".format(channel_name),
-    )

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
@@ -1,0 +1,45 @@
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from sqlalchemy.orm.session import Session
+
+from quetz.db_models import PackageVersion
+from quetz.deps import get_db
+
+router = APIRouter()
+
+
+@router.get("/api/channels/{channel_name}/conda-suggest")
+def get_conda_suggest(channel_name, db: Session = Depends(get_db)):
+    all_packages = (
+        db.query(PackageVersion)
+        .filter(PackageVersion.channel_name == channel_name)
+        .all()
+    )
+
+    channel_suggest_map = {}
+    error = False
+    for each_package in all_packages:
+        if not each_package.files:
+            error = True
+        else:
+            files_data = json.loads(each_package.files.data)
+            for (k, v) in files_data.items():
+                channel_suggest_map[k] = v
+
+    if error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="files for all packages not found",
+        )
+
+    with open("{0}.map".format(channel_name), "w") as f:
+        for (k, v) in sorted(channel_suggest_map.items()):
+            f.write("{0}:{1}\n".format(k, v))
+
+    return FileResponse(
+        "{0}.map".format(channel_name),
+        media_type="application/octet-stream",
+        filename="{0}.map".format(channel_name),
+    )

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
@@ -10,6 +10,8 @@ class CondaSuggestMetadata(Base):
     version_id = Column(UUID, ForeignKey("package_versions.id"), primary_key=True)
     package_version = relationship(
         "PackageVersion",
-        backref=backref("binfiles", uselist=False, cascade="delete,all"),
+        backref=backref(
+            "binfiles", uselist=False, cascade="delete,all", passive_deletes=True
+        ),
     )
     data = Column(String)

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
@@ -11,7 +11,9 @@ class CondaSuggestMetadata(Base):
     package_version = relationship(
         "PackageVersion",
         backref=backref(
-            "binfiles", uselist=False, cascade="delete,all", passive_deletes=True
+            "binfiles",
+            uselist=False,
+            cascade="delete,all",
         ),
     )
     data = Column(String)

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import backref, relationship
+
+from quetz.db_models import UUID, Base
+
+
+class CondaSuggestMetadata(Base):
+    __tablename__ = "quetz_conda_suggest_metadata"
+
+    version_id = Column(UUID, ForeignKey("package_versions.id"), primary_key=True)
+    package_version = relationship(
+        "PackageVersion",
+        backref=backref("files", uselist=False, cascade="delete,all"),
+    )
+    data = Column(String)

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/db_models.py
@@ -10,6 +10,6 @@ class CondaSuggestMetadata(Base):
     version_id = Column(UUID, ForeignKey("package_versions.id"), primary_key=True)
     package_version = relationship(
         "PackageVersion",
-        backref=backref("files", uselist=False, cascade="delete,all"),
+        backref=backref("binfiles", uselist=False, cascade="delete,all"),
     )
     data = Column(String)

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -1,7 +1,9 @@
 import json
+import os
 from contextlib import contextmanager
 
 import quetz
+from quetz.db_models import PackageVersion
 from quetz.deps import get_db
 
 from . import db_models
@@ -18,9 +20,9 @@ def register_router():
 @quetz.hookimpl
 def post_add_package_version(version, condainfo):
     suggest_map = {}
-    files_listing = condainfo.files
+    subdir = condainfo.info["subdir"]
 
-    for each_file in files_listing:
+    for each_file in condainfo.files:
         if each_file.startswith(b"bin/"):
             command = each_file.split(b"bin/")[1].strip().decode("utf-8").split("/")[0]
             package = condainfo.info["name"]
@@ -28,7 +30,7 @@ def post_add_package_version(version, condainfo):
                 suggest_map[command] = package
 
     with get_db() as db:
-        if not version.files:
+        if not version.binfiles:
             metadata = db_models.CondaSuggestMetadata(
                 version_id=version.id, data=json.dumps(suggest_map)
             )
@@ -37,3 +39,32 @@ def post_add_package_version(version, condainfo):
             metadata = db.query(db_models.CondaSuggestMetadata).get(version.id)
             metadata.data = json.dumps(suggest_map)
         db.commit()
+        generate_channel_suggest_map(db, version.channel_name, subdir)
+
+
+def generate_channel_suggest_map(db, channel_name, subdir):
+    all_packages = (
+        db.query(PackageVersion)
+        .filter(PackageVersion.channel_name == channel_name)
+        .filter(PackageVersion.platform == subdir)
+        .all()
+    )
+
+    channel_suggest_map = {}
+
+    for each_package in all_packages:
+        if not each_package.binfiles:
+            pass
+        else:
+            files_data = json.loads(each_package.binfiles.data)
+            for (k, v) in files_data.items():
+                channel_suggest_map[k] = v
+
+    map_filename = "{0}.{1}.map".format(channel_name, subdir)
+    map_filepath = os.path.join(
+        os.getcwd(), "channels", channel_name, subdir, map_filename
+    )
+
+    with open(map_filepath, "w") as f:
+        for (k, v) in sorted(channel_suggest_map.items()):
+            f.write("{0}:{1}\n".format(k, v))

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -31,8 +31,6 @@ def post_add_package_version(version, condainfo):
             if command not in suggest_map:
                 suggest_map[command] = package
 
-    print(suggest_map)  # this works for the last test
-
     with get_db() as db:
         if not version.binfiles:
             metadata = db_models.CondaSuggestMetadata(
@@ -73,8 +71,6 @@ def generate_channel_suggest_map(db, channel_name, subdir):
         )
         .all()
     )
-
-    print(all_packages)  # this is empty for the last test i.e. []
 
     channel_suggest_map = {}
 

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -31,6 +31,8 @@ def post_add_package_version(version, condainfo):
             if command not in suggest_map:
                 suggest_map[command] = package
 
+    print(suggest_map)  # this works for the last test
+
     with get_db() as db:
         if not version.binfiles:
             metadata = db_models.CondaSuggestMetadata(
@@ -71,6 +73,8 @@ def generate_channel_suggest_map(db, channel_name, subdir):
         )
         .all()
     )
+
+    print(all_packages)  # this is empty for the last test i.e. []
 
     channel_suggest_map = {}
 

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -83,10 +83,11 @@ def generate_channel_suggest_map(db, channel_name, subdir):
                 channel_suggest_map[k] = v
 
     map_filename = "{0}.{1}.map".format(channel_name, subdir)
-    map_filepath = os.path.join(
-        os.getcwd(), "channels", channel_name, subdir, map_filename
-    )
+    map_filepath = os.path.join(os.getcwd(), "channels", channel_name, subdir)
 
-    with open(map_filepath, "w") as f:
+    if not os.path.exists(map_filepath):
+        os.makedirs(map_filepath)
+
+    with open(os.path.join(map_filepath, map_filename), "w") as f:
         for (k, v) in sorted(channel_suggest_map.items()):
             f.write("{0}:{1}\n".format(k, v))

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -1,0 +1,39 @@
+import json
+from contextlib import contextmanager
+
+import quetz
+from quetz.deps import get_db
+
+from . import db_models
+from .api import router
+
+get_db = contextmanager(get_db)
+
+
+@quetz.hookimpl
+def register_router():
+    return router
+
+
+@quetz.hookimpl
+def post_add_package_version(version, condainfo):
+    suggest_map = {}
+    files_listing = condainfo.files
+
+    for each_file in files_listing:
+        if each_file.startswith(b"bin/"):
+            command = each_file.split(b"bin/")[1].strip().decode("utf-8").split("/")[0]
+            package = condainfo.info["name"]
+            if command not in suggest_map:
+                suggest_map[command] = package
+
+    with get_db() as db:
+        if not version.files:
+            metadata = db_models.CondaSuggestMetadata(
+                version_id=version.id, data=json.dumps(suggest_map)
+            )
+            db.add(metadata)
+        else:
+            metadata = db.query(db_models.CondaSuggestMetadata).get(version.id)
+            metadata.data = json.dumps(suggest_map)
+        db.commit()

--- a/plugins/quetz_conda_suggest/setup.py
+++ b/plugins/quetz_conda_suggest/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="quetz-conda_suggest",
+    install_requires="quetz",
+    entry_points={"quetz": ["quetz-conda_suggest = quetz_conda_suggest.main"]},
+    packages=["quetz_conda_suggest"],
+)

--- a/plugins/quetz_conda_suggest/tests/conftest.py
+++ b/plugins/quetz_conda_suggest/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "quetz.testing.fixtures"

--- a/plugins/quetz_conda_suggest/tests/conftest.py
+++ b/plugins/quetz_conda_suggest/tests/conftest.py
@@ -81,8 +81,8 @@ def package_version(user, channel, db, dao, package):
 
 
 @fixture
-def subdir(package_version):
-    return package_version.platform
+def subdir():
+    return "linux-64"
 
 
 @fixture

--- a/plugins/quetz_conda_suggest/tests/conftest.py
+++ b/plugins/quetz_conda_suggest/tests/conftest.py
@@ -1,1 +1,101 @@
+import json
+import uuid
+
+from pytest import fixture
+from quetz_conda_suggest import db_models
+
+from quetz import rest_models
+from quetz.dao import Dao
+from quetz.db_models import User
+
 pytest_plugins = "quetz.testing.fixtures"
+
+
+@fixture
+def dao(db) -> Dao:
+    return Dao(db)
+
+
+@fixture
+def user(db):
+    user = User(id=uuid.uuid4().bytes, username="madhurt")
+    db.add(user)
+    db.commit()
+    yield user
+
+
+@fixture
+def channel(dao, user, db):
+    channel_data = rest_models.Channel(
+        name="test_channel",
+        private=False,
+    )
+
+    channel = dao.create_channel(channel_data, user.id, "owner")
+
+    yield channel
+
+    db.delete(channel)
+    db.commit()
+
+
+@fixture
+def package(dao, user, channel, db):
+    new_package_data = rest_models.Package(name="test-package")
+
+    package = dao.create_package(
+        channel.name,
+        new_package_data,
+        user_id=user.id,
+        role="owner",
+    )
+
+    yield package
+
+    db.delete(package)
+    db.commit()
+
+
+@fixture
+def package_version(user, channel, db, dao, package):
+    package_format = 'tarbz2'
+    package_info = '{"size": 5000, "subdir": "linux-64"}'
+
+    version = dao.create_version(
+        channel.name,
+        package.name,
+        package_format,
+        "linux-64",
+        "0.1",
+        "0",
+        "0",
+        "test-package-0.1-0.tar.bz2",
+        package_info,
+        user.id,
+    )
+
+    yield version
+
+    db.delete(version)
+    db.commit()
+
+
+@fixture
+def subdir(package_version):
+    return package_version.platform
+
+
+@fixture
+def package_conda_suggest(package_version, db):
+    meta = db_models.CondaSuggestMetadata(
+        version_id=package_version.id,
+        data=json.dumps({"test-bin": "test-package"}),
+    )
+
+    db.add(meta)
+    db.commit()
+
+    yield meta
+
+    db.delete(meta)
+    db.commit()

--- a/plugins/quetz_conda_suggest/tests/test_main.py
+++ b/plugins/quetz_conda_suggest/tests/test_main.py
@@ -1,6 +1,0 @@
-def test_conda_suggest_endpoint(client):
-    pass
-    # response = client.get("/api/conda_suggest")
-
-    # assert response.status_code == 200
-    # assert response.json() == {"message": "Hello world!"}

--- a/plugins/quetz_conda_suggest/tests/test_main.py
+++ b/plugins/quetz_conda_suggest/tests/test_main.py
@@ -1,0 +1,6 @@
+def test_conda_suggest_endpoint(client):
+    pass
+    # response = client.get("/api/conda_suggest")
+
+    # assert response.status_code == 200
+    # assert response.json() == {"message": "Hello world!"}

--- a/plugins/quetz_conda_suggest/tests/test_quetz_conda_suggest.py
+++ b/plugins/quetz_conda_suggest/tests/test_quetz_conda_suggest.py
@@ -1,0 +1,77 @@
+import shutil
+import tempfile
+from contextlib import contextmanager
+from unittest import mock
+
+from quetz_conda_suggest import db_models
+
+from quetz.condainfo import CondaInfo
+
+
+def test_conda_suggest_endpoint_without_upload(client, channel, subdir, session_maker):
+    response = client.get(
+        f"/api/channels/{channel.name}/{subdir}/conda-suggest"
+    )  # noqa
+    assert response.status_code == 404
+    assert response.json() == {
+        'detail': 'conda-suggest map file for test_channel.linux-64 not found'
+    }
+
+
+def test_post_add_package_version(package_version, db, config, session_maker):
+    filename = "test-package-0.1-0.tar.bz2"
+
+    with tempfile.SpooledTemporaryFile(mode='wb') as target:
+        with open(filename, 'rb') as fid:
+            shutil.copyfileobj(fid, target)
+        target.seek(0)
+        condainfo = CondaInfo(target, filename)
+
+    @contextmanager
+    def get_db():
+        yield db
+
+    from quetz_conda_suggest import main
+
+    with mock.patch("quetz_conda_suggest.main.get_db", get_db):
+        main.post_add_package_version(package_version, condainfo)
+
+    meta = db.query(db_models.CondaSuggestMetadata).first()
+
+    assert meta.data == '{}'
+
+    # modify `files` and re-save
+    condainfo.files = [
+        b'bin/test-bin\n',
+        b'include/tpkg.h\n',
+        b'include/tpkg_utils.h\n',
+        b'lib/cmake/test-package/tpkgConfig.cmake\n',
+        b'lib/cmake/test-package/tpkgConfigVersion.cmake\n',
+        b'lib/libtpkg.so\n',
+        b'lib/pkgconfig/libtpkg.pc\n',
+    ]
+    with mock.patch("quetz_conda_suggest.main.get_db", get_db):
+        main.post_add_package_version(package_version, condainfo)
+
+    meta = db.query(db_models.CondaSuggestMetadata).all()
+
+    assert len(meta) == 1
+    assert meta[0].data == '{"test-bin": "test-package"}'
+
+
+def test_conda_suggest_endpoint_with_upload(
+    client, channel, package, subdir, config, session_maker
+):
+    response = client.get("/api/dummylogin/madhurt")
+
+    filename = "test-package-0.1-0.tar.bz2"
+    url = f'/api/channels/{channel.name}/files/'
+    files = [('files', open(filename, 'rb'))]
+    response = client.post(url, files=files)
+
+    # assert response.status_code == 201
+
+    response = client.get(
+        f"/api/channels/{channel.name}/{subdir}/conda-suggest"
+    )  # noqa
+    print(response.status_code)

--- a/plugins/quetz_conda_suggest/tests/test_quetz_conda_suggest.py
+++ b/plugins/quetz_conda_suggest/tests/test_quetz_conda_suggest.py
@@ -8,7 +8,7 @@ from quetz_conda_suggest import db_models
 from quetz.condainfo import CondaInfo
 
 
-def test_conda_suggest_endpoint_without_upload(client, channel, subdir, session_maker):
+def test_conda_suggest_endpoint_without_upload(client, channel, subdir):
     response = client.get(
         f"/api/channels/{channel.name}/{subdir}/conda-suggest"
     )  # noqa
@@ -18,7 +18,7 @@ def test_conda_suggest_endpoint_without_upload(client, channel, subdir, session_
     }
 
 
-def test_post_add_package_version(package_version, db, config, session_maker):
+def test_post_add_package_version(package_version, db, config):
     filename = "test-package-0.1-0.tar.bz2"
 
     with tempfile.SpooledTemporaryFile(mode='wb') as target:
@@ -59,17 +59,15 @@ def test_post_add_package_version(package_version, db, config, session_maker):
     assert meta[0].data == '{"test-bin": "test-package"}'
 
 
-def test_conda_suggest_endpoint_with_upload(
-    client, channel, package, subdir, config, session_maker
-):
+def test_conda_suggest_endpoint_with_upload(client, channel, package, subdir, config):
     response = client.get("/api/dummylogin/madhurt")
 
     filename = "test-package-0.1-0.tar.bz2"
     url = f'/api/channels/{channel.name}/files/'
-    files = [('files', open(filename, 'rb'))]
+    files = {'files': (filename, open(filename, 'rb'))}
     response = client.post(url, files=files)
 
-    # assert response.status_code == 201
+    assert response.status_code == 201
 
     response = client.get(
         f"/api/channels/{channel.name}/{subdir}/conda-suggest"

--- a/plugins/quetz_runexports/quetz_runexports/db_models.py
+++ b/plugins/quetz_runexports/quetz_runexports/db_models.py
@@ -10,6 +10,8 @@ class PackageVersionMetadata(Base):
     version_id = Column(UUID, ForeignKey("package_versions.id"), primary_key=True)
     package_version = relationship(
         "PackageVersion",
-        backref=backref("runexports", uselist=False, cascade="delete,all"),
+        backref=backref(
+            "runexports", uselist=False, cascade="delete,all", passive_deletes=True
+        ),
     )
     data = Column(String)

--- a/plugins/quetz_runexports/quetz_runexports/db_models.py
+++ b/plugins/quetz_runexports/quetz_runexports/db_models.py
@@ -11,7 +11,9 @@ class PackageVersionMetadata(Base):
     package_version = relationship(
         "PackageVersion",
         backref=backref(
-            "runexports", uselist=False, cascade="delete,all", passive_deletes=True
+            "runexports",
+            uselist=False,
+            cascade="delete,all",
         ),
     )
     data = Column(String)

--- a/quetz/condainfo.py
+++ b/quetz/condainfo.py
@@ -50,6 +50,7 @@ class CondaInfo:
         self.about = {}
         self.paths = {}
         self.run_exports = {}
+        self.files = {}
         self._parse_conda(file, filename)
 
     def _map_channeldata(self):
@@ -106,6 +107,9 @@ class CondaInfo:
         self.info = json.load(tar.extractfile("info/index.json"))
         self.about = json.load(tar.extractfile("info/about.json"))
         self.paths = json.load(tar.extractfile("info/paths.json"))
+        with tar.extractfile("info/files") as fp:
+            self.files = fp.readlines()
+
         try:
             exports_file = tar.extractfile("info/run_exports.json")
         except KeyError:


### PR DESCRIPTION
This is without `tests` for now.

To use:
1) Create a new channel.
2) Upload some packages.
3) Hit the endpoint `/api/channels/{channel_name}/conda-suggest`

Maybe we should do creation of the `channel_suggest_map` and the `downloadable map file` as a background task?