### PR TITLE
server level user roles

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Contents
 
    configuration
    plugins 
+   qeps/index
 
 Indices and tables
 ------------------

--- a/docs/source/qeps/index.rst
+++ b/docs/source/qeps/index.rst
@@ -1,0 +1,8 @@
+Quetz enhancement proposals (QEPs)
+==================================
+
+.. toctree::
+   :maxdepth: 1
+
+   qep-001-user-permissions
+

--- a/docs/source/qeps/qep-001-user-permissions.rst
+++ b/docs/source/qeps/qep-001-user-permissions.rst
@@ -1,0 +1,96 @@
+QEP 1: quetz permission design
+------------------------------
+
+Problem
+^^^^^^^
+
+* there is currently no option to set user permissions at server level
+* all users that log with their github account can create channels and upload packages, which might be not desired especially if the server is visible on the public network
+
+Use cases
+^^^^^^^^^
+
+* allow or forbid users to create channels
+* allow or forbid users to mirror channels
+* superuser role - user that can modify all channels or modify user permissions
+
+Proposal
+^^^^^^^^
+
+Add role to user model: each user should have one of the roles: ``owner``, ``maintainer``, ``member``. By default new users should have no role assigned (role = null). server ``maintainer`` or ``owner`` can add a role of ``member`` for a user, that would allow them to create new channels (except mirror channels).
+
+Role permissions:
+
+* empty
+ 
+  - can modify their user data
+
+* ``member``
+
+  - can create normal channels
+
+* ``maintainer`` (admin)
+
+  - all above and
+  - can assign ``member`` role to users
+  - can read/modify all users' data
+  - can create mirror and proxy channels
+  - has access to all channels (including all private channels)
+
+* ``owner`` (super-admin)
+
+  - all above and
+  - can assign ``maintainer`` role to users
+
+The role can be modified by the PUT method to the endpoint `/api/users/{username}/role` with the following data:
+
+.. code::
+
+   {
+     "role": "ROLE"
+   }
+
+The role can be retrieved by the GET request to the same endpoint.
+
+Roles can be configure with a config file:
+
+.. code:: toml
+
+   [users]
+   # users with owner role
+   admins = ["wolfv"]
+   # users with maintainer role
+   maintainers = ["btel"]
+   # users with memeber role
+   members = ["some", "random", "name"]
+   # default role assigned to new users
+   # leave out if role should be null
+   default_role = "member" 
+   # create a default channel for new users named {username}
+   create_default_channel = False
+
+API key
+"""""""
+
+A user can create a server-wide API key with the same permissions as user, by the POST request to `/api/api-keys` endpoint, with the following data:
+
+
+.. code::
+
+   {
+     "description": "key description, does not have to be unique"
+     "roles": []
+   }
+
+Note that the roles list should remain empty. Adding channel or package roles to `roles` will **downgrade** the permissions of the key.
+
+Implementation
+^^^^^^^^^^^^^^
+
+Add a new ``role`` column to the User model in the database that can have one of 4 values ``owner``, ``maintainer``, ``member`` or ``null`` (actual null object, not the string).
+
+Discussion
+^^^^^^^^^^
+
+* the names of server roles, even though not optimal, were chosen such that they are the same as channel and package roles
+* this proposal does not allow user to have multiple roles, because the roles create hierarchical relationship i.e., ``owner`` > ``maintainer`` > ``member``

--- a/docs/source/qeps/qep-001-user-permissions.rst
+++ b/docs/source/qeps/qep-001-user-permissions.rst
@@ -23,7 +23,7 @@ Role permissions:
 
 * empty
  
-  - can modify their user data
+  - can read their user data
 
 * ``member``
 
@@ -33,7 +33,7 @@ Role permissions:
 
   - all above and
   - can assign ``member`` role to users
-  - can read/modify all users' data
+  - can read all users' data
   - can create mirror and proxy channels
   - has access to all channels (including all private channels)
 

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -49,7 +49,7 @@ class Rules:
 
         return user_id
 
-    def assert_read_user_role(self, requested_user_id):
+    def assert_read_user_data(self, requested_user_id):
 
         user_id = self.assert_user()
 

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -60,12 +60,22 @@ class Rules:
                 status_code=status.HTTP_403_FORBIDDEN, detail='No permission'
             )
 
-    def assert_change_user_role(self, requested_user_id):
+    def assert_assign_user_role(self, role: str):
         user_id = self.get_user()
 
-        if not self.assert_user_roles(user_id, [OWNER, MAINTAINER]):
+        if (
+            role == MAINTAINER
+            or role == OWNER
+            and not self.assert_user_roles(user_id, [OWNER])
+        ):
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail='No permission'
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail='only owner can set maintainer and owner roles',
+            )
+        if role == MEMBER and not self.assert_user_roles(user_id, [OWNER, MAINTAINER]):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail='only maintainer and owner can set user roles',
             )
 
     def assert_user_roles(self, user_id, roles: list):

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -60,12 +60,20 @@ class Rules:
                 status_code=status.HTTP_403_FORBIDDEN, detail='No permission'
             )
 
+    def assert_change_user_role(self, requested_user_id):
+        user_id = self.get_user()
+
+        if not self.assert_user_roles(user_id, [OWNER, MAINTAINER]):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail='No permission'
+            )
+
     def assert_user_roles(self, user_id, roles: list):
 
         return (
             self.db.query(User)
-            .filter(ChannelMember.user_id == user_id)
-            .filter(ChannelMember.role.in_(roles))
+            .filter(User.id == user_id)
+            .filter(User.role.in_(roles))
             .one_or_none()
         )
 

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -50,33 +50,35 @@ class Rules:
         return user_id
 
     def assert_read_user_role(self, requested_user_id):
+
         user_id = self.assert_user()
 
         if not (
             (requested_user_id == user_id)
-            or (self.assert_user_roles(user_id, [OWNER, MAINTAINER]))
+            or (self.assert_server_roles([OWNER, MAINTAINER]))
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail='No permission'
             )
 
     def assert_assign_user_role(self, role: str):
-        user_id = self.assert_user()
 
-        if (role == MAINTAINER or role == OWNER) and not self.assert_user_roles(
-            user_id, [OWNER]
+        if (role == MAINTAINER or role == OWNER) and not self.assert_server_roles(
+            [OWNER]
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail='only owner can set maintainer and owner roles',
             )
-        if role == MEMBER and not self.assert_user_roles(user_id, [OWNER, MAINTAINER]):
+        if role == MEMBER and not self.assert_server_roles([OWNER, MAINTAINER]):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail='only maintainer and owner can set user roles',
             )
 
-    def assert_user_roles(self, user_id, roles: list):
+    def assert_server_roles(self, roles: list):
+
+        user_id = self.assert_user()
 
         return (
             self.db.query(User)
@@ -186,6 +188,10 @@ class Rules:
         self.assert_channel_or_package_roles(
             channel_name, [OWNER, MAINTAINER], package_name, [OWNER, MAINTAINER]
         )
+
+    def assert_create_mirror_channel(self, channel_name: str):
+
+        pass
 
     def assert_synchronize_mirror(self, channel_name):
         self.assert_channel_roles(channel_name, [OWNER, MAINTAINER])

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -50,7 +50,7 @@ class Rules:
         return user_id
 
     def assert_read_user_role(self, requested_user_id):
-        user_id = self.get_user()
+        user_id = self.assert_user()
 
         if not (
             (requested_user_id == user_id)
@@ -61,12 +61,10 @@ class Rules:
             )
 
     def assert_assign_user_role(self, role: str):
-        user_id = self.get_user()
+        user_id = self.assert_user()
 
-        if (
-            role == MAINTAINER
-            or role == OWNER
-            and not self.assert_user_roles(user_id, [OWNER])
+        if (role == MAINTAINER or role == OWNER) and not self.assert_user_roles(
+            user_id, [OWNER]
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -188,6 +188,10 @@ class Rules:
 
         self.assert_server_roles([OWNER, MAINTAINER])
 
+    def assert_create_channel(self):
+
+        self.assert_server_roles([OWNER, MAINTAINER, MEMBER])
+
     def assert_create_proxy_channel(self):
 
         self.assert_server_roles([OWNER, MAINTAINER])

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -69,6 +69,13 @@ class Dao:
             .one_or_none()
         )
 
+    def set_user_role(self, username: str, role: str):
+        user = self.db.query(User).filter(User.username == username).one_or_none()
+
+        if user:
+            user.role = role
+            self.db.commit()
+
     def get_channels(
         self, skip: int, limit: int, q: Optional[str], user_id: Optional[bytes]
     ):

--- a/quetz/db_models.py
+++ b/quetz/db_models.py
@@ -37,6 +37,8 @@ class User(Base):
         'Profile', uselist=False, back_populates='user', cascade="all,delete-orphan"
     )
 
+    role = Column(String)
+
     @classmethod
     def find(cls, db, name):
         """Find a user by name.

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -389,9 +389,13 @@ def post_channel(
         )
 
     if new_channel.mirror_channel_url and new_channel.mirror_mode == "mirror":
+        auth.assert_create_mirror_channel()
         mirror.synchronize_packages(
             new_channel, dao, pkgstore, auth, session, background_tasks
         )
+
+    if new_channel.mirror_channel_url and new_channel.mirror_mode == "proxy":
+        auth.assert_create_proxy_channel()
 
     dao.create_channel(new_channel, user_id, authorization.OWNER)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -287,6 +287,12 @@ def get_user_role(
 ):
 
     user = dao.get_user_by_username(username)
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"User {username} not found"
+        )
+
     auth.assert_read_user_role(user.id)
 
     return {"role": user.role}
@@ -299,6 +305,13 @@ def set_user_role(
     dao: Dao = Depends(get_dao),
     auth: authorization.Rules = Depends(get_rules),
 ):
+
+    user = dao.get_user_by_username(username)
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"User {username} not found"
+        )
 
     auth.assert_assign_user_role(role.role)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -237,26 +237,38 @@ async def me(
     return profile
 
 
+def get_users_handler(dao, q, auth, skip, limit):
+
+    user_id = auth.assert_user()
+
+    results = dao.get_users(skip, limit, q)
+
+    user_list = results["result"] if "result" in results else results
+
+    if not auth.has_server_roles(
+        user_id, [authorization.OWNER, authorization.MAINTAINER]
+    ):
+        append_user = None
+        for user in user_list:
+            if user.id == user_id:
+                append_user = user
+        user_list.clear()
+        if append_user:
+            user_list.append(append_user)
+
+    for user in user_list:
+        user.id = str(uuid.UUID(bytes=user.id))
+
+    return results
+
+
 @api_router.get("/users", response_model=List[rest_models.User], tags=["users"])
 def get_users(
     dao: Dao = Depends(get_dao),
     q: str = None,
     auth: authorization.Rules = Depends(get_rules),
 ):
-
-    user_id = auth.assert_user()
-
-    user_list = dao.get_users(0, -1, q)
-
-    if not auth.has_server_roles(
-        user_id, [authorization.OWNER, authorization.MAINTAINER]
-    ):
-        user_list = [user for user in user_list if user.id == user_id]
-
-    for user in user_list:
-        user.id = str(uuid.UUID(bytes=user.id))
-
-    return user_list
+    return get_users_handler(dao, q, auth, 0, -1)
 
 
 @api_router.get(
@@ -269,12 +281,9 @@ def get_paginated_users(
     skip: int = 0,
     limit: int = 10,
     q: str = None,
+    auth: authorization.Rules = Depends(get_rules),
 ):
-    user_list = dao.get_users(skip, limit, q)
-    for user in user_list["result"]:
-        user.id = str(uuid.UUID(bytes=user.id))
-
-    return user_list
+    return get_users_handler(dao, q, auth, skip, limit)
 
 
 @api_router.get("/users/{username}", response_model=rest_models.User, tags=["users"])

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -419,6 +419,9 @@ def post_channel(
             detail=f"Channel {new_channel.name} exists",
         )
 
+    if not new_channel.mirror_channel_url:
+        auth.assert_create_channel()
+
     if new_channel.mirror_channel_url and new_channel.mirror_mode == "mirror":
         auth.assert_create_mirror_channel()
         mirror.synchronize_packages(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -276,6 +276,24 @@ def get_user(username: str, dao: Dao = Depends(get_dao)):
 
 
 @api_router.get(
+    "/users/{username}/role", response_model=rest_models.UserRole, tags=["users"]
+)
+def get_user_role(username: str, dao: Dao = Depends(get_dao)):
+
+    user = dao.get_user_by_username(username)
+
+    return {"role": user.role}
+
+
+@api_router.put("/users/{username}/role", tags=["users"])
+def set_user_role(
+    username: str, role: rest_models.UserRole, dao: Dao = Depends(get_dao)
+):
+
+    dao.set_user_role(username, role=role.role)
+
+
+@api_router.get(
     "/channels", response_model=List[rest_models.Channel], tags=["channels"]
 )
 def get_channels(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -245,9 +245,7 @@ def get_users_handler(dao, q, auth, skip, limit):
 
     user_list = results["result"] if "result" in results else results
 
-    if not auth.has_server_roles(
-        user_id, [authorization.OWNER, authorization.MAINTAINER]
-    ):
+    if not auth.is_user_elevated(user_id):
         append_user = None
         for user in user_list:
             if user.id == user_id:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -300,8 +300,7 @@ def set_user_role(
     auth: authorization.Rules = Depends(get_rules),
 ):
 
-    user = dao.get_user_by_username(username)
-    auth.assert_change_user_role(user.id)
+    auth.assert_assign_user_role(role.role)
 
     dao.set_user_role(username, role=role.role)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -276,19 +276,32 @@ def get_user(username: str, dao: Dao = Depends(get_dao)):
 
 
 @api_router.get(
-    "/users/{username}/role", response_model=rest_models.UserRole, tags=["users"]
+    "/users/{username}/role",
+    response_model=rest_models.UserRole,
+    tags=["users"],
 )
-def get_user_role(username: str, dao: Dao = Depends(get_dao)):
+def get_user_role(
+    username: str,
+    dao: Dao = Depends(get_dao),
+    auth: authorization.Rules = Depends(get_rules),
+):
 
     user = dao.get_user_by_username(username)
+    auth.assert_read_user_role(user.id)
 
     return {"role": user.role}
 
 
 @api_router.put("/users/{username}/role", tags=["users"])
 def set_user_role(
-    username: str, role: rest_models.UserRole, dao: Dao = Depends(get_dao)
+    username: str,
+    role: rest_models.UserRole,
+    dao: Dao = Depends(get_dao),
+    auth: authorization.Rules = Depends(get_rules),
 ):
+
+    user = dao.get_user_by_username(username)
+    auth.assert_read_user_role(user.id)
 
     dao.set_user_role(username, role=role.role)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -301,7 +301,7 @@ def set_user_role(
 ):
 
     user = dao.get_user_by_username(username)
-    auth.assert_read_user_role(user.id)
+    auth.assert_change_user_role(user.id)
 
     dao.set_user_role(username, role=role.role)
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -262,8 +262,14 @@ def get_paginated_users(
 
 
 @api_router.get("/users/{username}", response_model=rest_models.User, tags=["users"])
-def get_user(username: str, dao: Dao = Depends(get_dao)):
+def get_user(
+    username: str,
+    dao: Dao = Depends(get_dao),
+    auth: authorization.Rules = Depends(get_rules),
+):
     user = dao.get_user_by_username(username)
+
+    auth.assert_read_user_data(user.id)
 
     if not user:
         raise HTTPException(
@@ -293,7 +299,7 @@ def get_user_role(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"User {username} not found"
         )
 
-    auth.assert_read_user_role(user.id)
+    auth.assert_read_user_data(user.id)
 
     return {"role": user.role}
 

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -109,6 +109,10 @@ class PostMember(BaseModel):
     role: str = Role
 
 
+class UserRole(BaseModel):
+    role: str = Role
+
+
 class CPRole(BaseModel):
     channel: str
     package: Optional[str]

--- a/quetz/tests/test_auth.py
+++ b/quetz/tests/test_auth.py
@@ -29,7 +29,7 @@ class Data:
         Profile(name='userb', user=self.userb, avatar_url='')
         db.add(self.userb)
 
-        self.userc = User(id=uuid.uuid4().bytes, username='userc')
+        self.userc = User(id=uuid.uuid4().bytes, username='userc', role="owner")
         Profile(name='userc', user=self.userc, avatar_url='')
         db.add(self.userc)
 

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -84,6 +84,8 @@ def user_with_role_authenticated(user_with_role, client):
 
     assert response.status_code == 200
 
+    yield user_with_role
+
 
 def test_get_package_list(package_version, package_name, channel_name, client):
 
@@ -256,6 +258,7 @@ def test_get_user_permissions(
         assert response.json()["username"] == target_user
 
 
+@pytest.mark.parametrize("paginated", [False, True])
 @pytest.mark.parametrize(
     "user_role,query,expected_n_users",
     [
@@ -270,11 +273,16 @@ def test_get_user_permissions(
     ],
 )
 def test_get_users_permissions(
-    user_with_role_authenticated, other_user, client, expected_n_users, query
+    user_with_role_authenticated, other_user, client, expected_n_users, query, paginated
 ):
 
-    response = client.get(f"/api/users?q={query}")
+    if paginated:
+        response = client.get(f"/api/paginated/users?q={query}")
+        user_list = response.json()["result"]
+    else:
+        response = client.get(f"/api/users?q={query}")
+        user_list = response.json()
 
     assert response.status_code == 200
 
-    assert len(response.json()) == expected_n_users
+    assert len(user_list) == expected_n_users

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -159,7 +159,7 @@ def test_get_set_user_role(user, client, other_user, db):
     assert response.status_code == 200
     assert response.json() == {"role": None}
 
-    # maintainer/owner can elevate role to member
+    # maintainer can only elevate role to member
 
     response = client.put(
         f"/api/users/{other_user.username}/role", json={"role": "member"}
@@ -172,7 +172,22 @@ def test_get_set_user_role(user, client, other_user, db):
     assert response.status_code == 200
     assert response.json() == {"role": "member"}
 
-    # only owner can elevate the role to maintainer
+    # only owner can elevate the role to maintainer or owner
+
+    user.role = "owner"
+    db.commit()
+
+    for role_name in ["member", "maintainer", "owner"]:
+        response = client.put(
+            f"/api/users/{other_user.username}/role", json={"role": role_name}
+        )
+
+        assert response.status_code == 200
+
+        response = client.get(f"/api/users/{other_user.username}/role")
+
+        assert response.status_code == 200
+        assert response.json() == {"role": role_name}
 
     # test validation of role names
 

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -286,3 +286,21 @@ def test_get_users_permissions(
     assert response.status_code == 200
 
     assert len(user_list) == expected_n_users
+
+
+@pytest.mark.parametrize(
+    "user_role,expected_status",
+    [("owner", 201), ("maintainer", 201), ("member", 201), (None, 403)],
+)
+def test_create_normal_channel_permissions(
+    client, user_with_role_authenticated, expected_status
+):
+
+    response = client.post(
+        "/api/channels",
+        json={
+            "name": "test_create_channel",
+            "private": False,
+        },
+    )
+    assert response.status_code == expected_status

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -254,3 +254,27 @@ def test_get_user_permissions(
 
     if response.status_code == 200:
         assert response.json()["username"] == target_user
+
+
+@pytest.mark.parametrize(
+    "user_role,query,expected_n_users",
+    [
+        ("owner", "", 2),
+        ("maintainer", "", 2),
+        ("member", "", 1),
+        (None, "", 1),
+        ("owner", "bar", 1),
+        (None, "bar", 1),
+        ("owner", "oth", 1),
+        (None, "oth", 0),
+    ],
+)
+def test_get_users_permissions(
+    user_with_role_authenticated, other_user, client, expected_n_users, query
+):
+
+    response = client.get(f"/api/users?q={query}")
+
+    assert response.status_code == 200
+
+    assert len(response.json()) == expected_n_users

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -96,3 +96,30 @@ def test_package_version_list_by_date(
     )
     assert response.status_code == 200
     assert len(response.json()) == 1
+
+
+def test_get_set_user_role(user, client):
+    response = client.get("/api/dummylogin/bartosz")
+
+    assert response.status_code == 200
+
+    response = client.get("/api/users/bartosz/role")
+
+    assert response.status_code == 200
+    assert response.json() == {"role": None}
+
+    response = client.put("/api/users/bartosz/role", json={"role": "member"})
+
+    assert response.status_code == 200
+
+    response = client.get("/api/users/bartosz/role")
+
+    assert response.status_code == 200
+    assert response.json() == {"role": "member"}
+
+    # test validation of role names
+
+    response = client.put("/api/users/bartosz/role", json={"role": "UNDEFINED"})
+
+    assert response.status_code == 422
+    assert "member" in response.json()["detail"][0]["msg"]

--- a/quetz/tests/test_main.py
+++ b/quetz/tests/test_main.py
@@ -99,6 +99,18 @@ def test_package_version_list_by_date(
 
 
 def test_get_set_user_role(user, client):
+
+    # test permissions
+
+    response = client.get("/api/users/bartosz/role")
+
+    assert response.status_code == 403
+
+    response = client.put("/api/users/bartosz/role", json={"role": "member"})
+
+    assert response.status_code == 403
+
+    # test with logged user
     response = client.get("/api/dummylogin/bartosz")
 
     assert response.status_code == 200


### PR DESCRIPTION
implementation of the [QEP1](https://hackmd.io/brJub-gXSL6oXx7UoRqcQA) (part 1)



* empty
  - [x] can read their user data
* member
  - [x] can create normal channels
* maintainer (admin)
  - [x] all above and
  - [x] can assign member role to users
  - [x] can read/modify all users’ data
  - [x] can create mirror and proxy channels
  - [x] has access to all channels (including all private channels)
* owner (super-admin)
   - [x] all above and
   - [x] can assign maintainer role to users
