### PR TITLE
implement singleton config

### DIFF
--- a/quetz/config.py
+++ b/quetz/config.py
@@ -98,7 +98,6 @@ class Config:
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
-            print('Creating the object')
             cls._instance = super().__new__(cls, *args, **kwargs)
             # Put any initialization here.
             cls._instance.init(*args, **kwargs)

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -94,7 +94,17 @@ class Config:
     _config_dirs = [_site_dir, _user_dir]
     _config_files = [os.path.join(d, _filename) for d in _config_dirs]
 
-    def __init__(self, deployment_config: str = None) -> NoReturn:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            print('Creating the object')
+            cls._instance = super().__new__(cls, *args, **kwargs)
+            # Put any initialization here.
+            cls._instance.init(*args, **kwargs)
+        return cls._instance
+
+    def init(self, deployment_config: str = None) -> NoReturn:
         """Load configurations from various places.
 
         Order of importance for configuration is:

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -77,6 +77,8 @@ https_only = false
         dest = os.path.join(path, filename)
         if os.path.isfile(full_path):
             shutil.copy(full_path, dest)
+
+    Config._instance = None
     config = Config()
     yield config
     os.chdir(old_dir)


### PR DESCRIPTION
make Config a singleton class, so that we don't have to re-load the config values from the file each time the config is created

Note that for each use of Config, we  instatiate the class (`config = Config()`), which returns the singleton instance. This allows us to simply reset the instance in the tests.