### PR TITLE
Fix cli init db

### DIFF
--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -332,6 +332,7 @@ def create(
     Path('channels').mkdir()
     db = get_session(config.sqlalchemy_database_url)
 
+    init_db(abs_path)
     if dev:
         _fill_test_database(db)
 
@@ -441,7 +442,6 @@ def run(
 
     abs_path = os.path.abspath(path)
     create(abs_path, config_file_name, copy_conf, create_conf, dev)
-    init_db(abs_path)
     start(abs_path, port, host, proxy_headers, log_level, reload)
 
 

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -56,13 +56,14 @@ class LogLevel(str, Enum):
 def _init_db(db: Session, config: Config):
     """Initialize the database and add users from config."""
 
-    dao = Dao(db)
-    role_map = [
-        (config.users_admins, "owner"),
-        (config.users_maintainers, "maintainer"),
-        (config.users_members, "member"),
-    ]
     if config.configured_section("users"):
+        dao = Dao(db)
+        role_map = [
+            (config.users_admins, "owner"),
+            (config.users_maintainers, "maintainer"),
+            (config.users_members, "member"),
+        ]
+
         for users, role in role_map:
             for username in users:
                 logger.info(f"create user {username} with role {role}")

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -234,7 +234,7 @@ def init_db(
 ) -> NoReturn:
     """init database and fill users from config file [users] sections"""
 
-    logger.info("Initializing databbase")
+    logger.info("Initializing database")
 
     config_file = _get_config(path)
 

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -13,9 +13,12 @@ def user_group():
 
 @pytest.fixture
 def config_extra(user_group):
-    return f"""[users]
-    {user_group} = ["bartosz"]
-    """
+    if user_group is None:
+        return ""
+    else:
+        return f"""[users]
+                {user_group} = ["bartosz"]
+                """
 
 
 @pytest.mark.parametrize(
@@ -23,6 +26,7 @@ def config_extra(user_group):
     [("admins", "owner"), ("maintainers", "maintainer"), ("members", "member")],
 )
 def test_init_db(db, config, config_dir, user_group, expected_role):
+
     def get_db(_):
         return db
 
@@ -38,7 +42,20 @@ def test_init_db(db, config, config_dir, user_group, expected_role):
     assert not user.profile
 
 
-def test_init_db_user_exists(db, config, user, config_dir):
+@pytest.mark.parametrize("user_group", [None])
+def test_init_db_no_users(db, config, config_dir, user_group):
+    def get_db(_):
+        return db
+
+    with mock.patch("quetz.cli.get_session", get_db):
+        cli.init_db(config_dir)
+
+    user = db.query(User).filter(User.username == "bartosz").one_or_none()
+
+    assert user is None
+
+
+def test_init_db_user_exists(db, config, config_dir, user):
     def get_db(_):
         return db
 

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -21,11 +21,7 @@ def config_extra(user_group):
                 """
 
 
-@pytest.mark.parametrize(
-    "user_group,expected_role",
-    [("admins", "owner"), ("maintainers", "maintainer"), ("members", "member")],
-)
-def test_init_db(db, config, config_dir, user_group, expected_role):
+def get_user(db, config_dir):
 
     def get_db(_):
         return db
@@ -33,8 +29,15 @@ def test_init_db(db, config, config_dir, user_group, expected_role):
     with mock.patch("quetz.cli.get_session", get_db):
         cli.init_db(config_dir)
 
-    user = db.query(User).filter(User.username == "bartosz").one_or_none()
+    return db.query(User).filter(User.username == "bartosz").one_or_none()
 
+
+@pytest.mark.parametrize(
+    "user_group,expected_role",
+    [("admins", "owner"), ("maintainers", "maintainer"), ("members", "member")],
+)
+def test_init_db(db, config, config_dir, user_group, expected_role):
+    user = get_user(db, config_dir)
     assert user
 
     assert user.role == expected_role
@@ -43,27 +46,13 @@ def test_init_db(db, config, config_dir, user_group, expected_role):
 
 
 @pytest.mark.parametrize("user_group", [None])
-def test_init_db_no_users(db, config, config_dir, user_group):
-    def get_db(_):
-        return db
-
-    with mock.patch("quetz.cli.get_session", get_db):
-        cli.init_db(config_dir)
-
-    user = db.query(User).filter(User.username == "bartosz").one_or_none()
-
+def test_init_db_no_user(db, config, config_dir, user_group):
+    user = get_user(db, config_dir)
     assert user is None
 
 
 def test_init_db_user_exists(db, config, config_dir, user):
-    def get_db(_):
-        return db
-
-    with mock.patch("quetz.cli.get_session", get_db):
-        cli.init_db(config_dir)
-
-    user = db.query(User).filter(User.username == "bartosz").one_or_none()
-
+    user = get_user(db, config_dir)
     assert user
 
     assert user.role == 'owner'

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -22,7 +22,6 @@ def config_extra(user_group):
 
 
 def get_user(db, config_dir):
-
     def get_db(_):
         return db
 


### PR DESCRIPTION
Hi!

@btel @wolfv 
Seems the CLI is broken due to a database init using not required entries, thus sometimes attributes do not exist.
When passing one of the possible entries (as done in the current tests), the others are defaulting to empty lists, not causing an error.

BTW, the database init should not be done at `create` step and not `run` one ?
Calling cli command `quetz create ...` currently won't init the database.

My patch for the test fixture is maybe not ideal, I use the `pytest.mark.parametrize` decorator only to pass 1 argument/value.
Let me know if you have better ideas ;)

Thanks for your feedback!