### PR TITLE
fix setting permissions with init db

### DIFF
--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -239,6 +239,7 @@ def init_db(
     config_file = _get_config(path)
 
     config = Config(config_file)
+    os.chdir(path)
     db = get_session(config.sqlalchemy_database_url)
 
     _init_db(db, config)
@@ -332,7 +333,8 @@ def create(
     Path('channels').mkdir()
     db = get_session(config.sqlalchemy_database_url)
 
-    init_db(abs_path)
+    _init_db(db, config)
+
     if dev:
         _fill_test_database(db)
 

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -450,6 +450,7 @@ class Dao:
         if not user:
             user = User(id=uuid.uuid4().bytes, username=user_name, role=role)
             self.db.add(user)
+
         user.role = role
         self.db.commit()
         return user


### PR DESCRIPTION
fix to the bug: re-runing of quetz init-db would not change the permissions of exisiting or new users

this bug only occured  with sqlite and relative paths