### PR TITLE
adding re-indexing task

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,11 +348,12 @@ Mirror channels are read only (you can not add or change packages in these chann
 curl http://localhost:8000/api/channels/mirror-channel/packages
 ```
 
-If packages are added or modified on the primary server from which they were pulled initially, they won't be updated automatically in the mirror channel. However, you can trigger such synchronisation manually using the PUT `/api/channels/{channel_name}` endpoint:
+If packages are added or modified on the primary server from which they were pulled initially, they won't be updated automatically in the mirror channel. However, you can trigger such synchronisation manually using the PUT `/api/channels/{channel_name}/actions` endpoint:
 
 ```bash
-curl -X PUT localhost:8000/api/channels/mirror-channel \
-   -H "X-API-Key: ${QUETZ_API_KEY}"
+curl -X PUT localhost:8000/api/channels/mirror-channel/actions \
+   -H "X-API-Key: ${QUETZ_API_KEY}" \
+   -d '{"action": "synchronize"}'
 ```
 
 Only channel owners or maintainers are allowed to trigger synchronisation, therefore you have to provide a valid API key of a privileged user.

--- a/docs/source/using/mirroring.rst
+++ b/docs/source/using/mirroring.rst
@@ -82,11 +82,13 @@ Mirror channels are read only (you can not add or change packages in these chann
 Synchronising mirror channel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If packages are added or modified on the primary server from which they were pulled initially, they won't be updated automatically in the mirror channel. However, you can trigger such synchronisation manually using the PUT ``/api/channels/{channel_name}`` endpoint:
+If packages are added or modified on the primary server from which they were pulled initially, they won't be updated automatically in the mirror channel. However, you can trigger such synchronisation manually using the PUT ``/api/channels/{channel_name}/actions`` endpoint:
 
 
 .. code:: bash
 
-   curl -X PUT localhost:8000/api/channels/mirror-channel -H "X-API-Key: ${QUETZ_API_KEY}"
+   curl -X PUT localhost:8000/api/channels/mirror-channel/actions \ 
+       -H "X-API-Key: ${QUETZ_API_KEY}" \
+       -d '{"action": "synchronize"}'
 
 Only channel owners or maintainers are allowed to trigger synchronisation, therefore you have to provide a valid API key of a privileged user.

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -203,6 +203,9 @@ class Rules:
     def assert_synchronize_mirror(self, channel_name):
         self.assert_channel_roles(channel_name, [OWNER, MAINTAINER])
 
+    def assert_reindex_channel(self, channel_name):
+        self.assert_channel_roles(channel_name, [OWNER, MAINTAINER])
+
     def assert_overwrite_package_version(self, channel_name, package_name):
         self.assert_channel_or_package_roles(
             channel_name, [OWNER], package_name, [OWNER]

--- a/quetz/condainfo.py
+++ b/quetz/condainfo.py
@@ -138,7 +138,8 @@ class CondaInfo:
         self.info["sha256"] = sha.hexdigest()
 
     def _parse_conda(self, file, filename):
-        filehandle = file._file
+        file.seek(0)
+        filehandle = file
         if filename.endswith(".conda"):
             self.package_format = db_models.PackageFormatEnum.conda
             with ZipFile(filehandle) as zf:

--- a/quetz/condainfo.py
+++ b/quetz/condainfo.py
@@ -138,6 +138,11 @@ class CondaInfo:
         self.info["sha256"] = sha.hexdigest()
 
     def _parse_conda(self, file, filename):
+
+        # workaround for https://github.com/python/cpython/pull/3249
+        if not hasattr(file, "seekable"):
+            file.seekable = file._file.seekable
+
         file.seek(0)
         filehandle = file
         if filename.endswith(".conda"):

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -724,6 +724,11 @@ def handle_package_files(
 
     for file in files:
         logger.debug(f"adding file '{file.filename}' to channel '{channel_name}'")
+
+        # workaround for https://github.com/python/cpython/pull/3249
+        if not hasattr(file.file, "seekable"):
+            file.file.seekable = file.file._file.seekable
+
         condainfo = CondaInfo(file.file, file.filename)
 
         package_name = condainfo.info["name"]

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -725,10 +725,6 @@ def handle_package_files(
     for file in files:
         logger.debug(f"adding file '{file.filename}' to channel '{channel_name}'")
 
-        # workaround for https://github.com/python/cpython/pull/3249
-        if not hasattr(file.file, "seekable"):
-            file.file.seekable = file.file._file.seekable
-
         condainfo = CondaInfo(file.file, file.filename)
 
         package_name = condainfo.info["name"]

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -388,7 +388,7 @@ def get_channel(channel: db_models.Channel = Depends(get_channel_allow_proxy)):
 
 
 def can_channel_synchronize(channel):
-    return channel.mirror_mode == "mirror"
+    return channel.mirror_channel_url and (channel.mirror_mode == "mirror")
 
 
 def can_channel_reindex(channel):

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -27,6 +27,10 @@ class PackageStore(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def list_files(self, channel: str):
+        pass
+
+    @abc.abstractmethod
     def add_package(self, package: File, channel: str, destination: str) -> NoReturn:
         pass
 
@@ -84,6 +88,10 @@ class LocalStore(PackageStore):
 
     def serve_path(self, channel, src):
         return self.fs.open(path.join(self.channels_dir, channel, src)).f
+
+    def list_files(self, channel):
+        channel_dir = os.path.join(self.channels_dir, channel)
+        return [os.path.relpath(f, channel_dir) for f in self.fs.find(channel_dir)]
 
 
 class S3Store(PackageStore):

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -36,7 +36,7 @@ class PackageStore(abc.ABC):
 
     @abc.abstractmethod
     def add_file(
-        self, data: Union[str, BinaryIO], channel: str, destination: str
+        self, data: Union[str, bytes], channel: str, destination: str
     ) -> NoReturn:
         pass
 
@@ -79,7 +79,7 @@ class LocalStore(PackageStore):
             shutil.copyfileobj(package, f)
 
     def add_file(
-        self, data: Union[str, BinaryIO], channel: str, destination: str
+        self, data: Union[str, bytes], channel: str, destination: str
     ) -> NoReturn:
 
         mode = "w" if isinstance(data, str) else "wb"
@@ -152,7 +152,7 @@ class S3Store(PackageStore):
                     shutil.copyfileobj(package, pkg)
 
     def add_file(
-        self, data: Union[str, BinaryIO], channel: str, destination: str
+        self, data: Union[str, bytes], channel: str, destination: str
     ) -> NoReturn:
         if type(data) is str:
             mode = "w"

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -89,7 +89,7 @@ class LocalStore(PackageStore):
     def serve_path(self, channel, src):
         return self.fs.open(path.join(self.channels_dir, channel, src)).f
 
-    def list_files(self, channel):
+    def list_files(self, channel: str):
         channel_dir = os.path.join(self.channels_dir, channel)
         return [os.path.relpath(f, channel_dir) for f in self.fs.find(channel_dir)]
 
@@ -168,3 +168,13 @@ class S3Store(PackageStore):
     def serve_path(self, channel, src):
         with self._get_fs() as fs:
             return fs.open(path.join(self._bucket_map(channel), src))
+
+    def list_files(self, channel: str):
+        def remove_prefix(text, prefix):
+            if text.startswith(prefix):
+                return text[len(prefix) :].lstrip("/")  # noqa: E203
+            return text
+
+        channel_bucket = self._bucket_map(channel)
+
+        return [remove_prefix(f, channel_bucket) for f in self.fs.find(channel_bucket)]

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, Field, validator
@@ -144,3 +145,11 @@ class PackageVersion(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class ChannelActionEnum(str, Enum):
+    synchronize = 'synchronize'
+
+
+class ChannelAction(BaseModel):
+    action: ChannelActionEnum

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -149,6 +149,7 @@ class PackageVersion(BaseModel):
 
 class ChannelActionEnum(str, Enum):
     synchronize = 'synchronize'
+    reindex = "reindex"
 
 
 class ChannelAction(BaseModel):

--- a/quetz/tasks.py
+++ b/quetz/tasks.py
@@ -1,0 +1,88 @@
+import json
+import logging
+
+from sqlalchemy.exc import IntegrityError
+
+from quetz import authorization, rest_models
+from quetz.condainfo import CondaInfo
+from quetz.config import Config
+from quetz.dao import Dao
+from quetz.database import get_session
+
+logger = logging.getLogger("quetz.tasks")
+
+
+def handle_file(
+    channel_name,
+    filename,
+    file_buffer,
+    dao,
+    user_id,
+):
+
+    logger.debug(f"adding file '{filename}' to channel '{channel_name}'")
+    condainfo = CondaInfo(file_buffer, filename)
+
+    package_name = condainfo.info["name"]
+
+    dao.create_package(
+        channel_name,
+        rest_models.Package(
+            name=package_name,
+            summary=condainfo.about.get("summary", "n/a"),
+            description=condainfo.about.get("description", "n/a"),
+        ),
+        user_id,
+        authorization.OWNER,
+    )
+
+    # Update channeldata info
+    dao.update_package_channeldata(channel_name, package_name, condainfo.channeldata)
+
+    try:
+        version = dao.create_version(
+            channel_name=channel_name,
+            package_name=package_name,
+            package_format=condainfo.package_format,
+            platform=condainfo.info["subdir"],
+            version=condainfo.info["version"],
+            build_number=condainfo.info["build_number"],
+            build_string=condainfo.info["build"],
+            filename=filename,
+            info=json.dumps(condainfo.info),
+            uploader_id=user_id,
+            upsert=False,
+        )
+    except IntegrityError:
+        logger.error(f"duplicate package '{package_name}' in channel '{channel_name}'")
+        raise
+
+    return version
+
+
+def reindex_packages_from_store(config: Config, channel_name: str, user_id: bytes):
+    """Reindex packages from files in the package store"""
+
+    db = get_session(config.sqlalchemy_database_url)
+    dao = Dao(db)
+
+    pkgstore = config.get_package_store()
+
+    all_files = pkgstore.list_files(channel_name)
+    pkg_files = [f for f in all_files if f.endswith(".tar.bz2")]
+
+    channel = dao.get_channel(channel_name)
+
+    if channel:
+        for package in channel.packages:
+            db.delete(package)
+        db.commit()
+    else:
+        data = rest_models.Channel(
+            name=channel_name, description="re-indexed from files", private=True
+        )
+        channel = dao.create_channel(data, user_id, authorization.OWNER)
+
+    for fname in pkg_files:
+        fid = pkgstore.serve_path(channel_name, fname)
+        handle_file(channel_name, fname, fid, dao, user_id)

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -790,15 +790,37 @@ def test_repo_without_channeldata(owner, client, dummy_repo, expected_archs):
 
 def test_sync_mirror_channel(mirror_channel, user, client, dummy_repo):
 
-    response = client.put(f"/api/channels/{mirror_channel.name}")
+    response = client.put(
+        f"/api/channels/{mirror_channel.name}/actions", json={"action": "synchronize"}
+    )
 
     assert response.status_code == 401
 
     response = client.get("/api/dummylogin/bartosz")
     assert response.status_code == 200
 
-    response = client.put(f"/api/channels/{mirror_channel.name}")
+    response = client.put(
+        f"/api/channels/{mirror_channel.name}/actions", json={"action": "synchronize"}
+    )
     assert response.status_code == 200
+
+
+def test_sync_local_channel(local_channel, user, client, dummy_repo):
+    response = client.put(
+        f"/api/channels/{local_channel.name}/actions", json={"action": "synchronize"}
+    )
+
+    assert response.status_code == 405
+    assert "synchronize not allowed" in response.json()["detail"]
+
+    response = client.get("/api/dummylogin/bartosz")
+    assert response.status_code == 200
+
+    response = client.put(
+        f"/api/channels/{local_channel.name}/actions", json={"action": "synchronize"}
+    )
+    assert response.status_code == 405
+    assert "synchronize not allowed" in response.json()["detail"]
 
 
 def test_can_not_sync_proxy_and_local_channels(

--- a/quetz/tests/test_tasks.py
+++ b/quetz/tests/test_tasks.py
@@ -1,0 +1,48 @@
+from unittest import mock
+
+import pytest
+
+from quetz.db_models import Channel
+from quetz.pkgstores import PackageStore
+from quetz.tasks import reindex_packages_from_store
+
+
+@pytest.fixture
+def channel_name():
+    return "my-channel"
+
+
+@pytest.fixture
+def pkgstore(config):
+    pkgstore = config.get_package_store()
+    return pkgstore
+
+
+@pytest.fixture
+def package_files(pkgstore: PackageStore, channel_name):
+    pkgstore.create_channel(channel_name)
+    filename = "test-package-0.1-0.tar.bz2"
+    with open(filename, 'rb') as fid:
+        content = fid.read()
+    pkgstore.add_file(content, channel_name, f"linux-64/{filename}")
+
+
+@pytest.fixture
+def channel(dao, user, channel_name):
+
+    channel_data = Channel(name=channel_name, private=False)
+    channel = dao.create_channel(channel_data, user.id, "owner")
+
+    return channel
+
+
+def test_reindex_package_files(config, user, package_files, channel, db):
+    user_id = user.id
+    with mock.patch("quetz.tasks.get_session", lambda _: db):
+        reindex_packages_from_store(config, channel.name, user_id)
+    db.refresh(channel)
+
+    assert channel.packages
+    assert channel.packages[0].name == "test-package"
+    assert channel.packages[0].members[0].user.username == user.username
+    assert channel.packages[0].package_versions[0].version == '0.1'


### PR DESCRIPTION
allow reindexing files stored in the the package store:

to reindex packages make the following request:

```
PUT /api/channels/{channel_name}/actions
```

with the body:

```
{"action": "reindex"}
```

Note 1:  the packages have to be in the path of the store that is consistent with the channel_name, for local store this would be: `{deployment_dir}/channels/{channel_name}/...`
Note 2: the channel has to be created beforehand
~~Note 3: for mirror channels you should rather use `{"action": "synchronize"}` (only for mirror_mode=mirror), the synchronisation protocol will find the files automatically in the store~~ (it's not true, you still need to reindex to get the metadata from package files, but for the moment, we don't have a way to prevent synchronisation when creating mirror channels)