### PR TITLE
Disable mirror sync on demand

### DIFF
--- a/docs/source/using/mirroring.rst
+++ b/docs/source/using/mirroring.rst
@@ -79,6 +79,21 @@ Mirror channels are read only (you can not add or change packages in these chann
 
    curl http://localhost:8000/api/channels/mirror-channel/packages
 
+You can also postpone the synchronising the channel by adding ``{"metadata": {"actions": []}}`` to the request:
+
+.. code:: bash
+
+   curl -X POST "http://localhost:8000/api/channels" \
+       -H  "accept: application/json" \
+       -H  "Content-Type: application/json" \
+       -H  "X-API-Key: ${QUETZ_API_KEY}" \
+       -d '{"name":"mirror-channel",
+            "private":false,
+            "mirror_channel_url":"https://conda.anaconda.org/btel",
+            "mirror_mode":"mirror",
+            "metadata": {"actions": []}}'
+
+
 Synchronising mirror channel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -92,3 +107,38 @@ If packages are added or modified on the primary server from which they were pul
        -d '{"action": "synchronize"}'
 
 Only channel owners or maintainers are allowed to trigger synchronisation, therefore you have to provide a valid API key of a privileged user.
+
+
+Re-indexing existing package files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If for some reason the database was deleted, but the package files are still in the package store, you can re-create the mirror channel and re-index the existing package files, by sending the POST request to `/api/channels` with data:
+
+.. code:: json
+
+   {
+     "name":"ORIGINAL-CHANNEL-NAME",
+     "private":false,
+     "mirror_channel_url":"ORIGINAL-URL",
+     "mirror_mode":"mirror",
+      "metadata": {
+        "actions": ["reindex"]}
+   }
+
+For example, to re-index the ``mirror-channel`` from previous example, you would use:
+
+.. code:: bash
+
+   curl -X POST "http://localhost:8000/api/channels" \
+       -H  "accept: application/json" \
+       -H  "Content-Type: application/json" \
+       -H  "X-API-Key: ${QUETZ_API_KEY}" \
+       -d '{"name":"mirror-channel",
+            "private":false,
+            "mirror_channel_url":"https://conda.anaconda.org/btel",
+            "mirror_mode":"mirror",
+            "metadata": {"actions": ["reindex"]}}'
+
+This request will add existing package files to the repository, but it won't trigger a new synchronisation. If you want to synchronise the channel you can follow the example from the previous section. This synchronisation should only attempt to download the files that were not present in the package store.
+
+

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -872,6 +872,9 @@ def handle_package_files(
 
         dest = os.path.join(condainfo.info["subdir"], file.filename)
         file.file._file.seek(0)
+        logger.debug(
+            f"uploading file {dest} from channel {channel_name} to package store"
+        )
         pkgstore.add_package(file.file, channel_name, dest)
 
         pm.hook.post_add_package_version(version=version, condainfo=condainfo)

--- a/quetz/mirror.py
+++ b/quetz/mirror.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 
 from quetz import authorization, indexing
 from quetz.dao import Dao
+from quetz.db_models import Channel
 from quetz.pkgstores import PackageStore
 
 # copy common subdirs from conda:
@@ -146,7 +147,7 @@ class LocalCache:
 
 
 @contextlib.contextmanager
-def _check_timestamp(channel, dao: Dao):
+def _check_timestamp(channel: Channel, dao: Dao):
     """context manager for comparing the package timestamp
     last synchroninsation timestamp saved in quetz database."""
 
@@ -155,8 +156,10 @@ def _check_timestamp(channel, dao: Dao):
 
     def _func(package_name, metadata):
 
-        if "time_modified" not in metadata:
+        if "time_modified" not in metadata or not last_synchronisation:
             return None
+
+        logger.debug(f"comparing synchronisation timestamps of {package_name}")
 
         # use nonlocal to be able to modified last_timestamp in the
         # outer scope
@@ -187,9 +190,11 @@ def _check_checksum(
     def _func(package_name, metadata):
         # use nonlocal to be able to modified last_timestamp in the
         # outer scope
+
         if keyname not in metadata:
             return None
 
+        logger.debug(f"comparing {keyname} checksums of {package_name}")
         nonlocal local_repodata
         if not local_repodata:
             try:

--- a/quetz/mirror.py
+++ b/quetz/mirror.py
@@ -156,25 +156,30 @@ def _check_timestamp(channel: Channel, dao: Dao):
 
     def _func(package_name, metadata):
 
-        if "time_modified" not in metadata or not last_synchronisation:
+        if "time_modified" not in metadata:
             return None
-
-        logger.debug(f"comparing synchronisation timestamps of {package_name}")
 
         # use nonlocal to be able to modified last_timestamp in the
         # outer scope
         nonlocal last_timestamp
         time_modified = metadata["time_modified"]
-        is_uptodate = time_modified <= last_synchronization
         last_timestamp = max(time_modified, last_timestamp)
+
+        # if channel was never synchronised we can't determine
+        # whether the package is up-to-date from the timestamp
+        is_uptodate = (
+            time_modified <= last_synchronization if last_synchronization else None
+        )
+        if is_uptodate is not None:
+            logger.debug(f"comparing synchronisation timestamps of {package_name}")
         return is_uptodate
 
     yield _func
 
     # after we are done, we need to update the last_synchronisation
     # in the db
-    last_synchronisation = max(last_synchronization, last_timestamp)
-    dao.update_channel(channel.name, {"timestamp_mirror_sync": last_synchronisation})
+    sync_timestamp = max(last_synchronization, last_timestamp)
+    dao.update_channel(channel.name, {"timestamp_mirror_sync": sync_timestamp})
 
 
 @contextlib.contextmanager

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -77,7 +77,24 @@ class ChannelBase(BaseModel):
         orm_mode = True
 
 
+class ChannelActionEnum(str, Enum):
+    synchronize = 'synchronize'
+    reindex = "reindex"
+
+
+class ChannelMetadata(BaseModel):
+
+    actions: Optional[List[ChannelActionEnum]] = Field(
+        None, title="list of actions to run after channel creation"
+    )
+
+
 class Channel(ChannelBase):
+
+    metadata: ChannelMetadata = Field(
+        default_factory=ChannelMetadata, title="channel metadata"
+    )
+
     @root_validator
     def check_passwords_match(cls, values):
         mirror_url = values.get("mirror_channel_url")
@@ -159,11 +176,6 @@ class PackageVersion(BaseModel):
 
     class Config:
         orm_mode = True
-
-
-class ChannelActionEnum(str, Enum):
-    synchronize = 'synchronize'
-    reindex = "reindex"
 
 
 class ChannelAction(BaseModel):

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -92,7 +92,7 @@ class ChannelMetadata(BaseModel):
 class Channel(ChannelBase):
 
     metadata: ChannelMetadata = Field(
-        default_factory=ChannelMetadata, title="channel metadata"
+        default_factory=ChannelMetadata, title="channel metadata", example={}
     )
 
     @root_validator

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -628,6 +628,25 @@ def test_mirror_initial_sync(client, dummy_repo, owner, expected_paths):
     assert dummy_repo == [os.path.join(host, p) for p in expected_paths]
 
 
+@pytest.mark.parametrize("user_role", ['maintainer'])
+def test_add_mirror_without_sync(auth_client, dummy_repo):
+
+    host = "http://mirror3_host"
+    response = auth_client.post(
+        "/api/channels",
+        json={
+            "name": "mirror_channel_" + str(uuid.uuid4())[:10],
+            "private": False,
+            "mirror_channel_url": host,
+            "mirror_mode": "mirror",
+            "metadata": {"actions": []},
+        },
+    )
+    assert response.status_code == 201
+
+    assert not dummy_repo
+
+
 empty_archive = b""
 
 


### PR DESCRIPTION
To re-create a mirror channel and re-index already downloaded files use `POST /api/channels` request with data:

```json
{
"name":"ORIGINAL-CHANNEL-NAME",
"private":false,
"mirror_channel_url":"ORIGINAL-URL",
"mirror_mode":"mirror",
 "metadata": {
   "actions": ["reindex"]}
}
```

(note that there is `reindex` under actions, but no `synchronize`)

for example:

```bash
curl -X POST "http://localhost:8000/api/channels"     \
  -H  "accept: application/json" \
  -H  "Content-Type: application/json"
  -H  "X-API-Key: ${QUETZ_API_KEY}"
  -d '{"name":"mirror-channel",
       "private":false,
       "mirror_channel_url":"https://conda.anaconda.org/btel",
       "mirror_mode":"mirror",
       "metadata": {"actions": ["reindex"]}}'
```

This request will not trigger synchronisation with the upstream server. However, you can synchronise the mirror channel afterwards by  sending the data `{"action": "synchronize"}` to `PUT /api/channels/{channel_name}/actions` endpoint:

```bash
curl -X PUT localhost:8000/api/channels/mirror-channel/actions \
 -H "X-api-key: ${QUETZ_API_KEY}" \
 -d '{"action": "synchronize"}'
```

only new packages will be downloaded