### PR TITLE
Add repodata_zchunk plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
           ./micromamba create -y -p ~/test_env 'python>=3.7' pip fastapi typer authlib \
                        httpx=0.12.0 sqlalchemy sqlite psycopg2 python-multipart uvicorn zstandard \
-                       appdirs toml fsspec conda requests "h2<4.0.0" starlette-full jinja2 itsdangerous alembic -c conda-forge
+                       appdirs toml fsspec conda requests "h2<4.0.0" starlette-full jinja2 itsdangerous alembic \
+                       zchunk -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: test quetz
@@ -90,9 +91,12 @@ jobs:
           echo "install and test plugins"
           pip install ./plugins/quetz_runexports
           pytest -v ./plugins/quetz_runexports/tests
-          
+
           pip install ./plugins/quetz_repodata_patching
           pytest -v ./plugins/quetz_repodata_patching
+
+          pip install ./plugins/quetz_repodata_zchunk
+          pytest -v ./plugins/quetz_repodata_zchunk
 
           pip install ./plugins/quetz_conda_suggest
           pytest -v ./plugins/quetz_conda_suggest

--- a/plugins/quetz_repodata_zchunk/README.md
+++ b/plugins/quetz_repodata_zchunk/README.md
@@ -1,0 +1,18 @@
+# quetz_repodata_zchunk plugin
+
+This is a plugin to use with the [quetz](https://github.com/mamba-org/quetz) package server that allows to serve/download the repodata using [zchunk](https://github.com/zchunk/zchunk), so that not all the repodata is downloaded every time it changes, but only the changed parts. This dramatically reduces the download time, and is more scalable in the long run (as repodata grows with time).
+
+
+## Installing
+
+To install use:
+
+```
+pip install .
+mamba install zchunk -c conda-forge
+```
+
+
+## Using
+
+After installing the package, the `repodata.json` from any channel will also be available in the zchunk format, and if you have a recent enough version of `mamba`, the repodata will be downloaded using `zckdl` (the zchunk download utility), providing all the benefits described above.

--- a/plugins/quetz_repodata_zchunk/quetz_repodata_zchunk/main.py
+++ b/plugins/quetz_repodata_zchunk/quetz_repodata_zchunk/main.py
@@ -1,0 +1,102 @@
+import bz2
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+
+import quetz
+from quetz.tasks.indexing import _jinjaenv
+
+
+def update_index(pkgstore, updated_files, channel_name, subdir, packages):
+    "update index.html in platform subdir"
+
+    add_files = []
+
+    for fname, data in updated_files:
+        md5 = hashlib.md5()
+        sha = hashlib.sha256()
+        if not isinstance(data, bytes):
+            data_bytes = data.encode("utf-8")
+        else:
+            data_bytes = data
+        md5.update(data_bytes)
+        sha.update(data_bytes)
+
+        add_files.append(
+            {
+                "name": f"{fname}",
+                "size": len(data_bytes),
+                "timestamp": datetime.now(timezone.utc),
+                "md5": md5.hexdigest(),
+                "sha256": sha.hexdigest(),
+            }
+        )
+
+    jinjaenv = _jinjaenv()
+    subdir_template = jinjaenv.get_template("subdir-index.html.j2")
+
+    pkgstore.add_file(
+        subdir_template.render(
+            title=f"{channel_name}/{subdir}",
+            packages=packages,
+            current_time=datetime.now(timezone.utc),
+            add_files=add_files,
+        ),
+        channel_name,
+        f"{subdir}/index.html",
+    )
+
+
+@quetz.hookimpl
+def post_package_indexing(
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs
+):
+    for subdir in subdirs:
+        updated_files = []
+        for fname in ["repodata"]:
+            fs = pkgstore.serve_path(channel_name, f"{subdir}/{fname}.json")
+
+            repodata_str = fs.read()
+            repodata = json.loads(repodata_str)
+
+            _, path1 = tempfile.mkstemp()
+            _, path2 = tempfile.mkstemp()
+
+            with open(path1, 'wb') as f:
+                f.write(repodata_str)
+
+            try:
+                subprocess.check_call(['zck', path1, '-o', path2])
+            except FileNotFoundError:
+                raise RuntimeError(
+                    'zchunk does not seem to be installed, '
+                    'you can install it with:\n'
+                    'mamba install zchunk -c conda-forge'
+                )
+            except subprocess.CalledProcessError:
+                raise RuntimeError('Error calling zck on repodata.')
+            finally:
+                os.remove(path1)
+
+            with open(path2, 'rb') as f:
+                repodata_zck = f.read()
+
+            os.remove(path2)
+
+            pkgstore.add_file(repodata_zck, channel_name, f'{subdir}/{fname}.json.zck')
+            updated_files.append((f'{fname}.json.zck', repodata_zck))
+
+            pkgstore.add_file(repodata_str, channel_name, f'{subdir}/{fname}.json')
+            updated_files.append((f'{fname}.json', repodata_str))
+
+            repodata_bz2 = bz2.compress(repodata_str)
+            pkgstore.add_file(repodata_bz2, channel_name, f'{subdir}/{fname}.json.bz2')
+            updated_files.append((f'{fname}.json.bz2', repodata_bz2))
+
+            packages = repodata["packages"]
+            packages.update(repodata["packages.conda"])
+
+        update_index(pkgstore, updated_files, channel_name, subdir, packages)

--- a/plugins/quetz_repodata_zchunk/quetz_repodata_zchunk/main.py
+++ b/plugins/quetz_repodata_zchunk/quetz_repodata_zchunk/main.py
@@ -1,102 +1,57 @@
 import bz2
-import hashlib
 import json
 import os
 import subprocess
 import tempfile
-from datetime import datetime, timezone
 
 import quetz
-from quetz.tasks.indexing import _jinjaenv
-
-
-def update_index(pkgstore, updated_files, channel_name, subdir, packages):
-    "update index.html in platform subdir"
-
-    add_files = []
-
-    for fname, data in updated_files:
-        md5 = hashlib.md5()
-        sha = hashlib.sha256()
-        if not isinstance(data, bytes):
-            data_bytes = data.encode("utf-8")
-        else:
-            data_bytes = data
-        md5.update(data_bytes)
-        sha.update(data_bytes)
-
-        add_files.append(
-            {
-                "name": f"{fname}",
-                "size": len(data_bytes),
-                "timestamp": datetime.now(timezone.utc),
-                "md5": md5.hexdigest(),
-                "sha256": sha.hexdigest(),
-            }
-        )
-
-    jinjaenv = _jinjaenv()
-    subdir_template = jinjaenv.get_template("subdir-index.html.j2")
-
-    pkgstore.add_file(
-        subdir_template.render(
-            title=f"{channel_name}/{subdir}",
-            packages=packages,
-            current_time=datetime.now(timezone.utc),
-            add_files=add_files,
-        ),
-        channel_name,
-        f"{subdir}/index.html",
-    )
+from quetz.utils import add_entry_for_index
 
 
 @quetz.hookimpl
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
 ):
     for subdir in subdirs:
-        updated_files = []
-        for fname in ["repodata"]:
-            fs = pkgstore.serve_path(channel_name, f"{subdir}/{fname}.json")
+        fname = "repodata"
+        fs = pkgstore.serve_path(channel_name, f"{subdir}/{fname}.json")
 
-            repodata_str = fs.read()
-            repodata = json.loads(repodata_str)
+        repodata_str = fs.read()
+        repodata = json.loads(repodata_str)
 
-            _, path1 = tempfile.mkstemp()
-            _, path2 = tempfile.mkstemp()
+        _, path1 = tempfile.mkstemp()
+        _, path2 = tempfile.mkstemp()
 
-            with open(path1, 'wb') as f:
-                f.write(repodata_str)
+        with open(path1, 'wb') as f:
+            f.write(repodata_str)
 
-            try:
-                subprocess.check_call(['zck', path1, '-o', path2])
-            except FileNotFoundError:
-                raise RuntimeError(
-                    'zchunk does not seem to be installed, '
-                    'you can install it with:\n'
-                    'mamba install zchunk -c conda-forge'
-                )
-            except subprocess.CalledProcessError:
-                raise RuntimeError('Error calling zck on repodata.')
-            finally:
-                os.remove(path1)
+        try:
+            subprocess.check_call(['zck', path1, '-o', path2])
+        except FileNotFoundError:
+            raise RuntimeError(
+                'zchunk does not seem to be installed, '
+                'you can install it with:\n'
+                'mamba install zchunk -c conda-forge'
+            )
+        except subprocess.CalledProcessError:
+            raise RuntimeError('Error calling zck on repodata.')
+        finally:
+            os.remove(path1)
 
-            with open(path2, 'rb') as f:
-                repodata_zck = f.read()
+        with open(path2, 'rb') as f:
+            repodata_zck = f.read()
 
-            os.remove(path2)
+        os.remove(path2)
 
-            pkgstore.add_file(repodata_zck, channel_name, f'{subdir}/{fname}.json.zck')
-            updated_files.append((f'{fname}.json.zck', repodata_zck))
+        pkgstore.add_file(repodata_zck, channel_name, f'{subdir}/{fname}.json.zck')
+        add_entry_for_index(files, subdir, f'{fname}.json.zck', repodata_zck)
 
-            pkgstore.add_file(repodata_str, channel_name, f'{subdir}/{fname}.json')
-            updated_files.append((f'{fname}.json', repodata_str))
+        pkgstore.add_file(repodata_str, channel_name, f'{subdir}/{fname}.json')
+        add_entry_for_index(files, subdir, f'{fname}.json', repodata_str)
 
-            repodata_bz2 = bz2.compress(repodata_str)
-            pkgstore.add_file(repodata_bz2, channel_name, f'{subdir}/{fname}.json.bz2')
-            updated_files.append((f'{fname}.json.bz2', repodata_bz2))
+        repodata_bz2 = bz2.compress(repodata_str)
+        pkgstore.add_file(repodata_bz2, channel_name, f'{subdir}/{fname}.json.bz2')
+        add_entry_for_index(files, subdir, f'{fname}.json.bz2', repodata_bz2)
 
-            packages = repodata["packages"]
-            packages.update(repodata["packages.conda"])
-
-        update_index(pkgstore, updated_files, channel_name, subdir, packages)
+        packages[subdir] = repodata["packages"]
+        packages[subdir].update(repodata["packages.conda"])

--- a/plugins/quetz_repodata_zchunk/setup.py
+++ b/plugins/quetz_repodata_zchunk/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="quetz-repodata_zchunk",
+    install_requires="quetz",
+    entry_points={"quetz": ["quetz-repodata_zchunk = quetz_repodata_zchunk.main"]},
+    packages=["quetz_repodata_zchunk"],
+)

--- a/plugins/quetz_repodata_zchunk/tests/conftest.py
+++ b/plugins/quetz_repodata_zchunk/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytest_plugins = "quetz.testing.fixtures"
+
+
+@pytest.fixture
+def plugins():
+    # defines plugins to enable for testing
+    return ['quetz-repodata_zchunk']

--- a/plugins/quetz_repodata_zchunk/tests/test_main.py
+++ b/plugins/quetz_repodata_zchunk/tests/test_main.py
@@ -2,8 +2,6 @@ import json
 import os
 import subprocess
 import uuid
-from contextlib import contextmanager
-from unittest import mock
 
 import pytest
 
@@ -114,12 +112,7 @@ def test_repodata_zchunk(
     dao,
     db,
 ):
-    @contextmanager
-    def get_db():
-        yield db
-
-    with mock.patch("quetz_repodata_patching.main.get_db_manager", get_db):
-        indexing.update_indexes(dao, pkgstore, channel_name)
+    indexing.update_indexes(dao, pkgstore, channel_name)
 
     index_path = os.path.join(
         pkgstore.channels_dir,
@@ -136,7 +129,7 @@ def test_repodata_zchunk(
     assert "repodata.json.bz2" in content
     assert "repodata.json.zck" in content
 
-    for fname in ("repodata.json", "current_repodata.json", "repodata.json.zck"):
+    for fname in ("repodata.json", "repodata.json.zck"):
 
         repodata_path = os.path.join(
             pkgstore.channels_dir, channel_name, "noarch", fname

--- a/plugins/quetz_repodata_zchunk/tests/test_main.py
+++ b/plugins/quetz_repodata_zchunk/tests/test_main.py
@@ -1,0 +1,155 @@
+import json
+import os
+import subprocess
+import uuid
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+import quetz
+from quetz.db_models import Channel, Package, Profile, User
+from quetz.tasks import indexing
+
+
+@pytest.fixture
+def user(db):
+    user = User(id=uuid.uuid4().bytes, username="bartosz")
+    profile = Profile(name="Bartosz", avatar_url="http:///avatar", user=user)
+    db.add(user)
+    db.add(profile)
+    db.commit()
+    yield user
+
+
+@pytest.fixture
+def channel_name():
+    return "my-channel"
+
+
+@pytest.fixture
+def package_name():
+    return "mytestpackage"
+
+
+@pytest.fixture
+def package_format():
+    return 'tarbz2'
+
+
+@pytest.fixture
+def package_file_name(package_name, package_format):
+    if package_format == 'tarbz2':
+        return f"{package_name}-0.1-0.tar.bz2"
+    elif package_format == "conda":
+        return f"{package_name}-0.1-0.conda"
+
+
+@pytest.fixture
+def channel(dao: "quetz.dao.Dao", channel_name, user):
+
+    channel_data = Channel(name=channel_name, private=False)
+    channel = dao.create_channel(channel_data, user.id, "owner")
+    return channel
+
+
+@pytest.fixture
+def package_subdir():
+    return "noarch"
+
+
+@pytest.fixture
+def package_version(
+    dao: "quetz.dao.Dao",
+    user,
+    channel,
+    package_name,
+    db,
+    package_file_name,
+    package_format,
+    package_subdir,
+):
+    channel_data = json.dumps({"subdirs": [package_subdir]})
+    package_data = Package(name=package_name)
+
+    package = dao.create_package(channel.name, package_data, user.id, "owner")
+    package.channeldata = channel_data
+    db.commit()
+
+    package_info = (
+        '{"run_exports": {"weak": ["otherpackage > 0.1"]}, "size": 100, "depends": []}'
+    )
+    version = dao.create_version(
+        channel.name,
+        package_name,
+        package_format,
+        package_subdir,
+        "0.1",
+        "0",
+        "0",
+        package_file_name,
+        package_info,
+        user.id,
+    )
+
+    yield version
+
+
+@pytest.fixture
+def archive_format():
+    return "tarbz2"
+
+
+@pytest.fixture
+def pkgstore(config):
+    pkgstore = config.get_package_store()
+    return pkgstore
+
+
+def test_repodata_zchunk(
+    pkgstore,
+    package_version,
+    channel_name,
+    package_file_name,
+    dao,
+    db,
+):
+    @contextmanager
+    def get_db():
+        yield db
+
+    with mock.patch("quetz_repodata_patching.main.get_db_manager", get_db):
+        indexing.update_indexes(dao, pkgstore, channel_name)
+
+    index_path = os.path.join(
+        pkgstore.channels_dir,
+        channel_name,
+        "noarch",
+        "index.html",
+    )
+
+    assert os.path.isfile(index_path)
+    with open(index_path, 'r') as fid:
+        content = fid.read()
+
+    assert "repodata.json" in content
+    assert "repodata.json.bz2" in content
+    assert "repodata.json.zck" in content
+
+    for fname in ("repodata.json", "current_repodata.json", "repodata.json.zck"):
+
+        repodata_path = os.path.join(
+            pkgstore.channels_dir, channel_name, "noarch", fname
+        )
+
+        assert os.path.isfile(repodata_path)
+
+        if fname.endswith('.zck'):
+            subprocess.check_call(['unzck', repodata_path])
+            with open('repodata.json') as f:
+                repodata_unzck = f.read()
+
+            assert repodata == repodata_unzck  # NOQA
+        else:
+            with open(repodata_path) as f:
+                repodata = f.read()  # NOQA


### PR DESCRIPTION
This PR implements partial download of the repodata using [zchunk](https://github.com/zchunk/zchunk). It should dramatically reduce repodata downloads when you already have an older repodata locally (which is the case most of the time). It will also require some work in mamba.
It's very much a work in progress, mainly to get early feedback.