### PR TITLE
current-repodata plugin + update conda-suggest and repodata-patching plugin

### DIFF
--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -34,7 +34,7 @@ def register_router():
 
 @quetz.hookimpl
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
 ):
     for subdir in subdirs:
         fname = f"{channel_name}.{subdir}.map"

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -1,6 +1,7 @@
+import hashlib
 import json
-import os
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 from sqlalchemy import and_, func
 
@@ -12,10 +13,12 @@ from quetz.db_models import PackageVersion
 from . import db_models
 from .api import router
 
+config = Config()
+pkgstore = config.get_package_store()
+
 
 @contextmanager
 def get_db_manager():
-    config = Config()
 
     db = get_session(config.sqlalchemy_database_url)
 
@@ -28,6 +31,35 @@ def get_db_manager():
 @quetz.hookimpl
 def register_router():
     return router
+
+
+@quetz.hookimpl
+def post_package_indexing(
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
+):
+    for subdir in subdirs:
+        fname = f"{channel_name}.{subdir}.map"
+        try:
+            f = pkgstore.serve_path(channel_name, f"{subdir}/{fname}")
+            data_bytes = f.read()
+
+            md5 = hashlib.md5()
+            sha = hashlib.sha256()
+
+            md5.update(data_bytes)
+            sha.update(data_bytes)
+
+            files[subdir].append(
+                {
+                    "name": fname,
+                    "size": len(data_bytes),
+                    "timestamp": datetime.now(timezone.utc),
+                    "md5": md5.hexdigest(),
+                    "sha256": sha.hexdigest(),
+                }
+            )
+        except FileNotFoundError:
+            pass
 
 
 @quetz.hookimpl
@@ -93,12 +125,10 @@ def generate_channel_suggest_map(db, channel_name, subdir):
             for (k, v) in files_data.items():
                 channel_suggest_map[k] = v
 
-    map_filename = "{0}.{1}.map".format(channel_name, subdir)
-    map_filepath = os.path.join(os.getcwd(), "channels", channel_name, subdir)
+    fname = f"{channel_name}.{subdir}.map"
+    path = f"{subdir}/{fname}"
+    data_bytes = "\n".join(
+        f"{k}:{v}" for (k, v) in sorted(channel_suggest_map.items())
+    ).encode("utf-8")
 
-    if not os.path.exists(map_filepath):
-        os.makedirs(map_filepath)
-
-    with open(os.path.join(map_filepath, map_filename), "w") as f:
-        for (k, v) in sorted(channel_suggest_map.items()):
-            f.write("{0}:{1}\n".format(k, v))
+    pkgstore.add_file(data_bytes, channel_name, path)

--- a/plugins/quetz_current_repodata/README.md
+++ b/plugins/quetz_current_repodata/README.md
@@ -2,6 +2,7 @@
 
 This is a plugin to use with the [quetz](https://github.com/mamba-org/quetz) package server.
 
+It generates `current_repodata.json` file specific to a particular channel (such as `conda-forge`) and a platform (such as `linux-64`). It is a trimmed version of `repodata.json` which contains the latest versions of each package. For more information, refer https://docs.conda.io/projects/conda-build/en/latest/concepts/generating-index.html#trimming-to-current-repodata
 
 ## Installing
 

--- a/plugins/quetz_current_repodata/README.md
+++ b/plugins/quetz_current_repodata/README.md
@@ -1,0 +1,12 @@
+# quetz_current_repodata plugin
+
+This is a plugin to use with the [quetz](https://github.com/mamba-org/quetz) package server.
+
+
+## Installing
+
+To install use:
+
+```
+pip install .
+```

--- a/plugins/quetz_current_repodata/quetz_current_repodata/main.py
+++ b/plugins/quetz_current_repodata/quetz_current_repodata/main.py
@@ -9,7 +9,7 @@ from quetz.utils import add_entry_for_index
 
 @quetz.hookimpl
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
 ):
     fname = "current_repodata.json"
     pins = {}

--- a/plugins/quetz_current_repodata/quetz_current_repodata/main.py
+++ b/plugins/quetz_current_repodata/quetz_current_repodata/main.py
@@ -1,0 +1,67 @@
+import bz2
+import hashlib
+import json
+from datetime import datetime, timezone
+
+from conda_build.index import _build_current_repodata
+from fastapi import APIRouter
+
+import quetz
+
+router = APIRouter()
+
+
+@quetz.hookimpl
+def register_router():
+    return router
+
+
+@quetz.hookimpl
+def post_package_indexing(
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
+):
+    fname = "current_repodata.json"
+    pins = {}
+    for subdir in subdirs:
+        updated_files = []
+
+        path = f"{subdir}/{fname}"
+        f = pkgstore.serve_path(channel_name, f"{subdir}/repodata.json")
+        repodata = json.load(f)
+
+        current_repodata = _build_current_repodata(subdir, repodata, pins)
+
+        raw_current_repodata = json.dumps(
+            current_repodata, indent=2, sort_keys=True
+        ).encode("utf-8")
+        compressed_current_repodata = bz2.compress(raw_current_repodata)
+
+        pkgstore.add_file(raw_current_repodata, channel_name, path)
+        pkgstore.add_file(compressed_current_repodata, channel_name, path + ".bz2")
+
+        updated_files.append((fname, raw_current_repodata))
+        updated_files.append((fname + ".bz2", compressed_current_repodata))
+
+        update_index(pkgstore, updated_files, channel_name, subdir, files)
+
+
+def update_index(pkgstore, updated_files, channel_name, subdir, files):
+    for fname, data in updated_files:
+        md5 = hashlib.md5()
+        sha = hashlib.sha256()
+        if not isinstance(data, bytes):
+            data_bytes = data.encode("utf-8")
+        else:
+            data_bytes = data
+        md5.update(data_bytes)
+        sha.update(data_bytes)
+
+        files[subdir].append(
+            {
+                "name": f"{fname}",
+                "size": len(data_bytes),
+                "timestamp": datetime.now(timezone.utc),
+                "md5": md5.hexdigest(),
+                "sha256": sha.hexdigest(),
+            }
+        )

--- a/plugins/quetz_current_repodata/quetz_current_repodata/main.py
+++ b/plugins/quetz_current_repodata/quetz_current_repodata/main.py
@@ -1,19 +1,10 @@
 import bz2
-import hashlib
 import json
-from datetime import datetime, timezone
 
 from conda_build.index import _build_current_repodata
-from fastapi import APIRouter
 
 import quetz
-
-router = APIRouter()
-
-
-@quetz.hookimpl
-def register_router():
-    return router
+from quetz.utils import add_entry_for_index
 
 
 @quetz.hookimpl
@@ -23,8 +14,6 @@ def post_package_indexing(
     fname = "current_repodata.json"
     pins = {}
     for subdir in subdirs:
-        updated_files = []
-
         path = f"{subdir}/{fname}"
         f = pkgstore.serve_path(channel_name, f"{subdir}/repodata.json")
         repodata = json.load(f)
@@ -39,29 +28,5 @@ def post_package_indexing(
         pkgstore.add_file(raw_current_repodata, channel_name, path)
         pkgstore.add_file(compressed_current_repodata, channel_name, path + ".bz2")
 
-        updated_files.append((fname, raw_current_repodata))
-        updated_files.append((fname + ".bz2", compressed_current_repodata))
-
-        update_index(pkgstore, updated_files, channel_name, subdir, files)
-
-
-def update_index(pkgstore, updated_files, channel_name, subdir, files):
-    for fname, data in updated_files:
-        md5 = hashlib.md5()
-        sha = hashlib.sha256()
-        if not isinstance(data, bytes):
-            data_bytes = data.encode("utf-8")
-        else:
-            data_bytes = data
-        md5.update(data_bytes)
-        sha.update(data_bytes)
-
-        files[subdir].append(
-            {
-                "name": f"{fname}",
-                "size": len(data_bytes),
-                "timestamp": datetime.now(timezone.utc),
-                "md5": md5.hexdigest(),
-                "sha256": sha.hexdigest(),
-            }
-        )
+        add_entry_for_index(files, subdir, fname, raw_current_repodata)
+        add_entry_for_index(files, subdir, f"{fname}.bz2", compressed_current_repodata)

--- a/plugins/quetz_current_repodata/setup.py
+++ b/plugins/quetz_current_repodata/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="quetz-current_repodata",
+    install_requires="quetz",
+    entry_points={"quetz": ["quetz-current_repodata = quetz_current_repodata.main"]},
+    packages=["quetz_current_repodata"],
+)

--- a/plugins/quetz_repodata_patching/quetz_repodata_patching/main.py
+++ b/plugins/quetz_repodata_patching/quetz_repodata_patching/main.py
@@ -108,7 +108,7 @@ def get_db_manager():
 
 @quetz.hookimpl
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
 ):
 
     with get_db_manager() as db:
@@ -151,7 +151,7 @@ def post_package_indexing(
         with extract_(fs) as tar:
 
             for subdir in subdirs:
-                packages = {}
+                packages[subdir] = {}
                 path = f"{subdir}/patch_instructions.json"
 
                 patch_instructions = _load_instructions(tar, path)
@@ -166,9 +166,8 @@ def post_package_indexing(
 
                 patch_repodata(repodata, patch_instructions)
 
-                if fname == 'repodata':
-                    packages.update(repodata["packages"])
-                    packages.update(repodata["packages.conda"])
+                packages[subdir].update(repodata["packages"])
+                packages[subdir].update(repodata["packages.conda"])
 
                 patched_repodata_str = json.dumps(repodata)
                 _addfile(patched_repodata_str, f"{fname}.json")

--- a/plugins/quetz_repodata_patching/quetz_repodata_patching/main.py
+++ b/plugins/quetz_repodata_patching/quetz_repodata_patching/main.py
@@ -1,9 +1,7 @@
 import bz2
-import hashlib
 import json
 import tarfile
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -13,7 +11,7 @@ import quetz
 from quetz.config import Config
 from quetz.database import get_session
 from quetz.db_models import PackageFormatEnum, PackageVersion
-from quetz.tasks.indexing import _jinjaenv
+from quetz.utils import add_entry_for_index
 
 
 def update_dict(packages, instructions):
@@ -96,46 +94,6 @@ def _load_instructions(tar, path):
     return patch_instructions
 
 
-def update_index(pkgstore, updated_files, channel_name, subdir, packages):
-    "update index.html in platform subdir"
-
-    add_files = []
-
-    for fname, data in updated_files:
-        md5 = hashlib.md5()
-        sha = hashlib.sha256()
-        if not isinstance(data, bytes):
-            data_bytes = data.encode("utf-8")
-        else:
-            data_bytes = data
-        md5.update(data_bytes)
-        sha.update(data_bytes)
-
-        add_files.append(
-            {
-                "name": f"{fname}",
-                "size": len(data_bytes),
-                "timestamp": datetime.now(timezone.utc),
-                "md5": md5.hexdigest(),
-                "sha256": sha.hexdigest(),
-            }
-        )
-
-    jinjaenv = _jinjaenv()
-    subdir_template = jinjaenv.get_template("subdir-index.html.j2")
-
-    pkgstore.add_file(
-        subdir_template.render(
-            title=f"{channel_name}/{subdir}",
-            packages=packages,
-            current_time=datetime.now(timezone.utc),
-            add_files=add_files,
-        ),
-        channel_name,
-        f"{subdir}/index.html",
-    )
-
-
 @contextmanager
 def get_db_manager():
     config = Config()
@@ -150,7 +108,7 @@ def get_db_manager():
 
 @quetz.hookimpl
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs
+    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files
 ):
 
     with get_db_manager() as db:
@@ -187,33 +145,30 @@ def post_package_indexing(
             pkgstore.add_file(content, channel_name, subdir_path)
             pkgstore.add_file(compressed_content, channel_name, subdir_path + ".bz2")
 
-            updated_files.append((path, content))
-            updated_files.append((path + ".bz2", compressed_content))
+            add_entry_for_index(files, subdir, path, content)
+            add_entry_for_index(files, subdir, f"{path}.bz2", compressed_content)
 
         with extract_(fs) as tar:
 
             for subdir in subdirs:
-                updated_files = []
                 packages = {}
                 path = f"{subdir}/patch_instructions.json"
 
                 patch_instructions = _load_instructions(tar, path)
 
-                for fname in ("repodata", "current_repodata"):
-                    fs = pkgstore.serve_path(channel_name, f"{subdir}/{fname}.json")
+                fname = "repodata"
+                fs = pkgstore.serve_path(channel_name, f"{subdir}/{fname}.json")
 
-                    repodata_str = fs.read()
-                    repodata = json.loads(repodata_str)
+                repodata_str = fs.read()
+                repodata = json.loads(repodata_str)
 
-                    _addfile(repodata_str, f"{fname}_from_packages.json")
+                _addfile(repodata_str, f"{fname}_from_packages.json")
 
-                    patch_repodata(repodata, patch_instructions)
+                patch_repodata(repodata, patch_instructions)
 
-                    if fname == 'repodata':
-                        packages.update(repodata["packages"])
-                        packages.update(repodata["packages.conda"])
+                if fname == 'repodata':
+                    packages.update(repodata["packages"])
+                    packages.update(repodata["packages.conda"])
 
-                    patched_repodata_str = json.dumps(repodata)
-                    _addfile(patched_repodata_str, f"{fname}.json")
-
-                update_index(pkgstore, updated_files, channel_name, subdir, packages)
+                patched_repodata_str = json.dumps(repodata)
+                _addfile(patched_repodata_str, f"{fname}.json")

--- a/plugins/quetz_repodata_patching/tests/test_main.py
+++ b/plugins/quetz_repodata_patching/tests/test_main.py
@@ -251,7 +251,7 @@ def pkgstore(config):
 
 
 @pytest.mark.parametrize("archive_format", ["tarbz2", "conda"])
-@pytest.mark.parametrize("repodata_stem", ["repodata", "current_repodata"])
+@pytest.mark.parametrize("repodata_stem", ["repodata"])
 @pytest.mark.parametrize("compressed_repodata", [False, True])
 @pytest.mark.parametrize(
     "revoke_instructions",
@@ -439,25 +439,25 @@ def test_patches_for_subdir(
     assert "repodata_from_packages.json" in content
     assert "repodata_from_packages.json.bz2" in content
 
-    for fname in ("repodata.json", "current_repodata.json"):
+    fname = "repodata.json"
 
-        repodata_path = os.path.join(
-            pkgstore.channels_dir, channel_name, package_subdir, fname
-        )
+    repodata_path = os.path.join(
+        pkgstore.channels_dir, channel_name, package_subdir, fname
+    )
 
-        assert os.path.isfile(repodata_path)
+    assert os.path.isfile(repodata_path)
 
-        with open(repodata_path) as fid:
-            data = json.load(fid)
+    with open(repodata_path) as fid:
+        data = json.load(fid)
 
-        packages = data["packages"]
+    packages = data["packages"]
 
-        pkg = packages[package_file_name]
+    pkg = packages[package_file_name]
 
-        if patches_subdir == package_subdir:
-            assert pkg['run_exports'] == {"weak": ["otherpackage > 0.2"]}
-        else:
-            assert pkg['run_exports'] == {"weak": ["otherpackage > 0.1"]}
+    if patches_subdir == package_subdir:
+        assert pkg['run_exports'] == {"weak": ["otherpackage > 0.2"]}
+    else:
+        assert pkg['run_exports'] == {"weak": ["otherpackage > 0.1"]}
 
 
 def test_no_repodata_patches_package(
@@ -491,24 +491,22 @@ def test_no_repodata_patches_package(
     assert "repodata_from_packages.json" not in content
     assert "repodata_from_packages.json.bz2" not in content
 
-    for fname in ("repodata.json", "current_repodata.json"):
+    fname = "repodata.json"
 
-        repodata_path = os.path.join(
-            pkgstore.channels_dir, channel_name, "noarch", fname
-        )
+    repodata_path = os.path.join(pkgstore.channels_dir, channel_name, "noarch", fname)
 
-        assert os.path.isfile(repodata_path)
+    assert os.path.isfile(repodata_path)
 
-        with open(repodata_path) as fid:
-            data = json.load(fid)
+    with open(repodata_path) as fid:
+        data = json.load(fid)
 
-        packages = data["packages"]
+    packages = data["packages"]
 
-        pkg = packages[package_file_name]
+    pkg = packages[package_file_name]
 
-        assert pkg['run_exports'] == {"weak": ["otherpackage > 0.1"]}
+    assert pkg['run_exports'] == {"weak": ["otherpackage > 0.1"]}
 
-        assert not pkg.get("revoked", False)
-        assert 'package_has_been_revoked' not in pkg["depends"]
+    assert not pkg.get("revoked", False)
+    assert 'package_has_been_revoked' not in pkg["depends"]
 
-        assert package_file_name not in data.get("removed", ())
+    assert package_file_name not in data.get("removed", ())

--- a/quetz/hooks.py
+++ b/quetz/hooks.py
@@ -37,6 +37,7 @@ def post_package_indexing(
     channel_name: str,
     subdirs: List[str],
     files: dict,
+    packages: dict,
 ) -> None:
     """hook for post-processsing after building indexes.
 
@@ -51,6 +52,10 @@ def post_package_indexing(
 
     :param dict files:
         a dict that contains list of files for each subdir
+        - used in updating the index
+
+    :param dict packages:
+        a dict that contains list of packages for each subdir
         - used in updating the index
     """
     pass

--- a/quetz/hooks.py
+++ b/quetz/hooks.py
@@ -49,5 +49,8 @@ def post_package_indexing(
     :param list subdirs:
         list of subdirs with indexes
 
+    :param dict files:
+        a dict that contains list of files for each subdir
+        - used in updating the index
     """
     pass

--- a/quetz/hooks.py
+++ b/quetz/hooks.py
@@ -33,7 +33,10 @@ def post_add_package_version(
 
 @hookspec
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name: str, subdirs: List[str]
+    pkgstore: "quetz.pkgstores.PackageStore",
+    channel_name: str,
+    subdirs: List[str],
+    files: dict,
 ) -> None:
     """hook for post-processsing after building indexes.
 

--- a/quetz/tasks/indexing.py
+++ b/quetz/tasks/indexing.py
@@ -133,7 +133,11 @@ def update_indexes(dao, pkgstore, channel_name, subdirs=None):
     pm = quetz.config.get_plugin_manager()
 
     pm.hook.post_package_indexing(
-        pkgstore=pkgstore, channel_name=channel_name, subdirs=subdirs, files=files
+        pkgstore=pkgstore,
+        channel_name=channel_name,
+        subdirs=subdirs,
+        files=files,
+        packages=packages,
     )
 
     for dir in subdirs:

--- a/quetz/utils.py
+++ b/quetz/utils.py
@@ -1,0 +1,23 @@
+# Copyright 2020 QuantStack
+# Distributed under the terms of the Modified BSD License.
+
+import hashlib
+from datetime import datetime, timezone
+
+
+def add_entry_for_index(files, subdir, fname, data_bytes):
+    md5 = hashlib.md5()
+    sha = hashlib.sha256()
+
+    md5.update(data_bytes)
+    sha.update(data_bytes)
+
+    files[subdir].append(
+        {
+            "name": fname,
+            "size": len(data_bytes),
+            "timestamp": datetime.now(timezone.utc),
+            "md5": md5.hexdigest(),
+            "sha256": sha.hexdigest(),
+        }
+    )


### PR DESCRIPTION
1. A new plugin `quetz_current_repodata` without an `api.py` i.e. no endpoint. Thus, it only contains the `hook`
2. The `index.html` is generated after all such `hooks` are called and the `files` parameter is updated (defined in `indexing.py`). This is different from using `pkgstore.list_files` since that would also give us data for multiple `subdirs` + would also list `packages` -- which is all extra information.
3. No tests are written for the new plugin `quetz_current_repodata` since there is no API endpoint.
4. The `quetz_conda_suggest` plugin is updated so as to use `pkgstore.add_file()` to create the `.map` file. It also updates the `index.html` so that `.map` appears in it.