### PR TITLE
add test reports to github action annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
           # install dev dependencies
           pip install -e .[dev]
+          pip install pytest-github-actions-annotate-failures
 
           if [ "$TEST_DB_BACKEND" == "postgres" ]; then
             export QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
@@ -88,7 +89,6 @@ jobs:
           export QUETZ_IS_TEST=1
 
           echo "testing server"
-          pip install -e .
           pytest -v ./quetz/tests/
 
           echo "install and test plugins"

--- a/quetz/tests/test_fastfail.py
+++ b/quetz/tests/test_fastfail.py
@@ -1,0 +1,2 @@
+def test_fail():
+    assert False

--- a/quetz/tests/test_fastfail.py
+++ b/quetz/tests/test_fastfail.py
@@ -1,2 +1,0 @@
-def test_fail():
-    assert False


### PR DESCRIPTION
logs are quite verbose and difficult to read. This PR adds annotations to the CI jobs with the name of failed tests. This uses this pytest plugin:

https://github.com/utgwkk/pytest-github-actions-annotate-failures