### PR TITLE
Delete user endpoint

### DIFF
--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -54,7 +54,14 @@ class Rules:
 
         return user_id
 
-    def assert_read_user_data(self, requested_user_id):
+    def assert_read_user_data(self, requested_user_id: bytes):
+
+        user_id = self.assert_user()
+
+        if not (requested_user_id == user_id):
+            self.assert_server_roles([SERVER_OWNER, SERVER_MAINTAINER])
+
+    def assert_delete_user(self, requested_user_id: bytes):
 
         user_id = self.assert_user()
 

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -82,6 +82,9 @@ class Dao:
         # only their identity providers and profiles
         self.db.query(Profile).filter(Profile.user_id == user_id).delete()
         self.db.query(Identity).filter(Identity.user_id == user_id).delete()
+        self.db.query(ApiKey).filter(
+            or_(ApiKey.user_id == user_id, ApiKey.owner_id == user_id)
+        ).delete()
         self.db.commit()
 
     def set_user_role(self, username: str, role: str):

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -77,6 +77,13 @@ class Dao:
             .one_or_none()
         )
 
+    def delete_user(self, user_id: bytes):
+        # we are not really removing users
+        # only their identity providers and profiles
+        self.db.query(Profile).filter(Profile.user_id == user_id).delete()
+        self.db.query(Identity).filter(Identity.user_id == user_id).delete()
+        self.db.commit()
+
     def set_user_role(self, username: str, role: str):
         user = self.db.query(User).filter(User.username == username).one_or_none()
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -314,6 +314,18 @@ def get_user(
     return user
 
 
+@api_router.delete("/users/{username}")
+def delete_user(
+    username: str,
+    dao: Dao = Depends(get_dao),
+    auth: authorization.Rules = Depends(get_rules),
+):
+    user = dao.get_user_by_username(username)
+
+    auth.assert_delete_user(user.id)
+    dao.delete_user(user.id)
+
+
 @api_router.get(
     "/users/{username}/role",
     response_model=rest_models.UserRole,

--- a/quetz/tests/api/conftest.py
+++ b/quetz/tests/api/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from quetz.config import Config
 from quetz.dao import Dao
-from quetz.db_models import Profile, User
+from quetz.db_models import Identity, Profile, User
 from quetz.rest_models import Channel, Package
 
 
@@ -50,8 +50,8 @@ def private_package_version(dao, private_channel, private_package, other_user, c
     filename = Path("test-package-0.1-0.tar.bz2")
 
     pkgstore = config.get_package_store()
-    with open(filename, 'rb') as fid:
-        pkgstore.add_file(fid.read(), channel_name, 'linux-64' / filename)
+    with open(filename, "rb") as fid:
+        pkgstore.add_file(fid.read(), channel_name, "linux-64" / filename)
 
     version = dao.create_version(
         private_channel.name,
@@ -76,8 +76,8 @@ def package_version(
 
     pkgstore = config.get_package_store()
     filename = Path("test-package-0.1-0.tar.bz2")
-    with open(filename, 'rb') as fid:
-        pkgstore.add_file(fid.read(), channel_name, 'linux-64' / filename)
+    with open(filename, "rb") as fid:
+        pkgstore.add_file(fid.read(), channel_name, "linux-64" / filename)
     package_format = "tarbz2"
     package_info = "{}"
     version = dao.create_version(
@@ -111,7 +111,14 @@ def other_user(other_user_without_profile, db):
     profile = Profile(
         name="Other", avatar_url="http:///avatar", user=other_user_without_profile
     )
+    identity = Identity(
+        provider="github",
+        identity_id="github",
+        username="btel",
+        user=other_user_without_profile,
+    )
     db.add(profile)
+    db.add(identity)
     db.commit()
     yield other_user_without_profile
 

--- a/quetz/tests/api/test_users.py
+++ b/quetz/tests/api/test_users.py
@@ -1,0 +1,206 @@
+import pytest
+
+from quetz.db_models import User
+
+
+def test_validate_user_role_names(user, client, other_user, db):
+
+    # test validation of role names
+
+    response = client.put("/api/users/bartosz/role", json={"role": "UNDEFINED"})
+
+    assert response.status_code == 422
+    assert "member" in response.json()["detail"][0]["msg"]
+
+
+@pytest.mark.parametrize(
+    "target_user,user_role,target_user_role,expected_status",
+    [
+        ("other", None, "member", 403),
+        ("other", "member", "member", 403),
+        ("other", "member", "maintainer", 403),
+        ("other", "member", "owner", 403),
+        ("other", "maintainer", "member", 200),
+        ("other", "maintainer", "maintainer", 403),
+        ("other", "maintainer", "owner", 403),
+        ("other", "owner", "member", 200),
+        ("other", "owner", "maintainer", 200),
+        ("other", "owner", "owner", 200),
+        ("missing_user", "owner", "member", 404),
+    ],
+)
+def test_set_user_role(
+    auth_client,
+    other_user,
+    target_user,
+    user_role,
+    target_user_role,
+    expected_status,
+):
+
+    # test changing role
+
+    response = auth_client.put(
+        f"/api/users/{target_user}/role", json={"role": target_user_role}
+    )
+    assert response.status_code == expected_status
+
+    # test if role assigned if previous request was successful
+    if response.status_code == 200:
+
+        get_response = auth_client.get(f"/api/users/{target_user}/role")
+
+        assert get_response.status_code == 200
+        assert get_response.json()["role"] == target_user_role
+
+
+@pytest.mark.parametrize(
+    "target_user,user_role,expected_status",
+    [
+        ("other", None, 403),
+        ("other", "member", 403),
+        ("other", "maintainer", 200),
+        ("other", "owner", 200),
+        ("bartosz", None, 200),
+        ("bartosz", "member", 200),
+        ("bartosz", "maintainer", 200),
+        ("bartosz", "owner", 200),
+    ],
+)
+def test_get_user_role(auth_client, other_user, target_user, expected_status, db):
+
+    # test reading the role
+
+    response = auth_client.get(f"/api/users/{target_user}/role")
+    assert response.status_code == expected_status
+
+    expected_role = db.query(User).filter(User.username == target_user).first().role
+
+    if response.status_code == 200:
+
+        assert response.json()["role"] == expected_role
+
+
+def test_get_set_user_role_without_login(user, client):
+    # test permissions without logged-in user
+
+    response = client.get("/api/users/bartosz/role")
+
+    assert response.status_code == 401
+
+    response = client.put("/api/users/bartosz/role", json={"role": "member"})
+
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "user_role,target_user,expected_status",
+    [
+        ("owner", "other", 200),
+        ("maintainer", "other", 200),
+        ("member", "other", 403),
+        (None, "other", 403),
+        ("owner", "bartosz", 200),
+        ("maintainer", "bartosz", 200),
+        ("member", "bartosz", 200),
+        (None, "bartosz", 200),
+    ],
+)
+def test_get_user_permissions(
+    other_user,
+    target_user,
+    auth_client,
+    expected_status,
+):
+
+    response = auth_client.get(f"/api/users/{target_user}")
+
+    assert response.status_code == expected_status
+
+    if response.status_code == 200:
+        assert response.json()["username"] == target_user
+
+
+@pytest.mark.parametrize("paginated", [False, True])
+@pytest.mark.parametrize(
+    "user_role,query,expected_n_users",
+    [
+        ("owner", "", 2),
+        ("maintainer", "", 2),
+        ("member", "", 1),
+        (None, "", 1),
+        ("owner", "bar", 1),
+        (None, "bar", 1),
+        ("owner", "oth", 1),
+        (None, "oth", 0),
+    ],
+)
+def test_get_users_permissions(
+    other_user, auth_client, expected_n_users, query, paginated
+):
+
+    if paginated:
+        response = auth_client.get(f"/api/paginated/users?q={query}")
+        user_list = response.json()["result"]
+    else:
+        response = auth_client.get(f"/api/users?q={query}")
+        user_list = response.json()
+
+    assert response.status_code == 200
+
+    assert len(user_list) == expected_n_users
+
+
+@pytest.mark.parametrize(
+    "user_role,target_user,expected_status",
+    [
+        ("owner", "other", 200),
+        ("maintainer", "other", 200),
+        ("member", "other", 403),
+        (None, "other", 403),
+        # user can always remove oneself
+        ("maintainer", "bartosz", 200),
+        ("member", "bartosz", 200),
+        (None, "bartosz", 200),
+    ],
+)
+def test_delete_user_permission(
+    other_user, auth_client, db, user_role, target_user, expected_status, user
+):
+
+    response = auth_client.delete(f"/api/users/{target_user}")
+
+    deleted_user = db.query(User).filter(User.username == target_user).one_or_none()
+
+    existing_user = db.query(User).filter(User.username == user.username).one_or_none()
+
+    if expected_status == 200:
+        assert response.status_code == 200
+        assert deleted_user
+        assert not deleted_user.profile
+        assert not deleted_user.identities
+        assert existing_user
+        assert existing_user.profile
+    else:
+
+        assert response.status_code == expected_status
+        assert deleted_user
+        assert deleted_user.profile
+        assert deleted_user.identities
+        assert existing_user
+        assert existing_user.profile
+
+
+@pytest.mark.parametrize("user_role", ["owner"])
+def test_get_users_without_profile(auth_client, other_user_without_profile, user):
+
+    response = auth_client.get("/api/users")
+
+    assert response.status_code == 200
+    users = response.json()
+    assert len(users) == 1
+    assert users[0]["username"] == user.username
+
+    response = auth_client.get(f"/api/users/{other_user_without_profile.username}")
+
+    assert response.status_code == 404


### PR DESCRIPTION
rather than deleting users we remove their profiles, identities and api keys. This allows us to keep the packages and channels, which might still be shared with others.