### PR TITLE
add --skip-if-exists to create and run commands

### DIFF
--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -398,7 +398,9 @@ def create(
 
     if os.path.exists(path) and abs_path in deployments:
         if skip_if_exists:
-            logger.info(f'Quetz deployment already exists at {path}, skipping creation.')
+            logger.info(
+                f'Quetz deployment already exists at {path}, skipping creation.'
+            )
             return
         delete_ = typer.confirm(f'Quetz deployment exists at {path}.\nOverwrite it?')
         if delete_:

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -377,6 +377,9 @@ def create(
         False,
         help="Enable/disable creation of a default configuration file",
     ),
+    skip_if_exists: bool = typer.Option(
+        False, help="Skip the creation if deployment already exists."
+    ),
     dev: bool = typer.Option(
         False,
         help=(
@@ -394,6 +397,9 @@ def create(
     deployments = _get_deployments()
 
     if os.path.exists(path) and abs_path in deployments:
+        if skip_if_exists:
+            logger.info(f'Quetz deployment already exists at {path}, skipping creation.')
+            return
         delete_ = typer.confirm(f'Quetz deployment exists at {path}.\nOverwrite it?')
         if delete_:
             delete(path, force=True)
@@ -528,6 +534,9 @@ def run(
         False,
         help="Enable/disable creation of a default configuration file",
     ),
+    skip_if_exists: bool = typer.Option(
+        False, help="Skip the creation if deployment already exists."
+    ),
     dev: bool = typer.Option(
         False,
         help=(
@@ -554,7 +563,7 @@ def run(
     It performs sequentially create and start operations."""
 
     abs_path = os.path.abspath(path)
-    create(abs_path, config_file_name, copy_conf, create_conf, dev)
+    create(abs_path, config_file_name, copy_conf, create_conf, skip_if_exists, dev)
     start(abs_path, port, host, proxy_headers, log_level, reload)
 
 

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -506,6 +506,16 @@ def start(
 
     config_file = _get_config(path)
 
+    abs_path = os.path.abspath(path)
+    deployments = _get_deployments()
+    if abs_path not in deployments:
+        typer.echo(
+            'The specified directory is not a deployment.\n'
+            'Use the create or run command to create a deployment.',
+            err=True,
+        )
+        raise typer.Abort()
+
     os.environ[_env_prefix + _env_config_file] = config_file
     os.chdir(path)
 


### PR DESCRIPTION
 added this option to be able to use a single command no matter if the deployment is present or not.

With this one can:

- set a docker container with the `quetz run --skip-if-exists deployment_name` as CMD;
- place the `deployment_name` configuration in an external directory;
- run the docker with a the external directory mounted as the working directory;
- run and restart the docker without any error.

not sure if the name of the option is good, at first I thought of `--exist-ok`.