### PR TITLE
remove deployments.json from CLI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - psycopg2
   - httpx=0.16.0
   - sqlalchemy
+  - sqlalchemy-utils
   - sqlite
   - python-multipart
   - uvicorn

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -395,7 +395,7 @@ def create(
             f.write(conf)
 
     os.environ[_env_prefix + _env_config_file] = str(config_file.resolve())
-    config = Config(config_file)
+    config = Config(str(config_file))
 
     deployment_folder.joinpath('channels').mkdir(exist_ok=True)
     with working_directory(path):

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -347,10 +347,11 @@ def create(
     if _is_deployment(deployment_folder):
         if exists_ok:
             logger.info(
-                f'Quetz deployment already exists at {path}, skipping creation.'
+                f'Quetz deployment already exists at {deployment_folder}.\n'
+                f'Skipping creation.'
             )
             return
-        if delete and copy_conf or create_conf:
+        if delete and (copy_conf or create_conf):
             shutil.rmtree(deployment_folder)
         else:
             typer.echo(
@@ -408,8 +409,7 @@ def create(
 
 def _get_config(path: Union[Path, str]) -> str:
     """get config path"""
-    path = Path(path)
-    config_file = path / 'config.toml'
+    config_file = Path(path) / 'config.toml'
     if not config_file.exists():
         typer.echo(f'Could not find config at {config_file}')
         raise typer.Abort()

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -478,6 +478,11 @@ def run(
         False,
         help="Enable/disable creation of a default configuration file",
     ),
+    delete: bool = typer.Option(
+        False,
+        help="Delete the the deployment if it exists. "
+        "Must be specified with --copy-conf or --create-conf",
+    ),
     skip_if_exists: bool = typer.Option(
         False, help="Skip the creation if deployment already exists."
     ),
@@ -507,7 +512,7 @@ def run(
     It performs sequentially create and start operations."""
 
     abs_path = os.path.abspath(path)
-    create(abs_path, copy_conf, create_conf, skip_if_exists, dev)
+    create(abs_path, copy_conf, create_conf, delete, skip_if_exists, dev)
     start(abs_path, port, host, proxy_headers, log_level, reload)
 
 

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -86,9 +86,8 @@ def test_init_db_create_test_users(db, config, mocker, config_dir):
     with mock.patch("quetz.cli.get_session", get_db):
         cli.create(
             Path(config_dir) / "new-deployment",
-            config_file_name="config.toml",
             copy_conf="config.toml",
-            create_conf=None,
+            create_conf=False,
             dev=True,
         )
 

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -10,9 +10,12 @@ import pytest
 import sqlalchemy as sa
 from alembic.script import ScriptDirectory
 from pytest_mock.plugin import MockerFixture
+from typer.testing import CliRunner
 
 from quetz import cli
 from quetz.db_models import Base, User
+
+runner = CliRunner()
 
 
 @pytest.fixture
@@ -87,7 +90,6 @@ def test_init_db_create_test_users(db, config, mocker, config_dir):
         cli.create(
             Path(config_dir) / "new-deployment",
             copy_conf="config.toml",
-            create_conf=False,
             dev=True,
         )
 
@@ -382,3 +384,85 @@ def test_multi_head(
         engine.execute("DROP TABLE alembic_version")
     except sa.exc.DatabaseError:
         pass
+
+
+def test_create_exists_ok():
+    """Nothing happens if --exists-ok is enabled."""
+    with mock.patch("quetz.cli._is_deployment", lambda x: True):
+        res = runner.invoke(cli.app, ["create", "test", "--exists-ok"])
+        assert res.exit_code == 0
+
+
+wrong_cli_args = [
+    ["create", "test"],
+    ["create", "test", "--copy-conf", "config.toml"],
+    ["create", "test", "--create-conf"],
+    ["create", "test", "--copy-conf", "config.toml", "--create-conf"],
+    ["create", "test", "--delete"],
+]
+
+
+@pytest.mark.parametrize('cli_args', wrong_cli_args)
+def test_create_exists_errors(cli_args):
+    """Create command raises if deployment exists and not force deleted."""
+    with mock.patch("quetz.cli._is_deployment", lambda x: True):
+        res = runner.invoke(cli.app, cli_args)
+        assert res.exit_code == 1
+        assert (
+            res.output == "Use the start command to start a deployment "
+            "or specify --delete with --copy-conf or --create-conf.\nAborted!\n"
+        )
+
+
+@pytest.fixture()
+def empty_deployment_dir() -> Path:
+    path = Path(tempfile.mkdtemp()).resolve()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def test_create_conf(empty_deployment_dir: Path):
+    """Create command with create conf cretes the needed files and folder."""
+    runner.invoke(cli.app, ['create', str(empty_deployment_dir), '--create-conf'])
+    assert empty_deployment_dir.joinpath('config.toml').exists()
+    assert empty_deployment_dir.joinpath('channels').exists()
+    assert empty_deployment_dir.joinpath('quetz.sqlite').exists()
+
+
+def test_create_exists_delete(empty_deployment_dir: Path):
+    """Existing deployment is removed if delete arg is used."""
+    runner.invoke(cli.app, ['create', str(empty_deployment_dir), '--create-conf'])
+    creation_time = empty_deployment_dir.stat().st_mtime
+    runner.invoke(
+        cli.app, ['create', str(empty_deployment_dir), '--delete', '--create-conf']
+    )
+    assert empty_deployment_dir.stat().st_mtime > creation_time
+    assert empty_deployment_dir.joinpath('config.toml').exists()
+    assert empty_deployment_dir.joinpath('channels').exists()
+    assert empty_deployment_dir.joinpath('quetz.sqlite').exists()
+
+
+def test_create_no_config(empty_deployment_dir: Path):
+    """Error on create command with empty deployment and no config."""
+    res = runner.invoke(cli.app, ['create', str(empty_deployment_dir)])
+    assert res.exit_code == 1
+    assert "No configuration file provided." in res.output
+
+
+def test_create_extra_file_in_deployment(empty_deployment_dir: Path):
+    """Error on create command with extra files in deployment."""
+    empty_deployment_dir.joinpath('extra_file.txt').touch()
+    res = runner.invoke(cli.app, ['create', str(empty_deployment_dir)])
+    assert res.exit_code == 1
+    assert "Quetz deployment not allowed at" in res.output
+
+
+def test_create_missing_copy_conf(empty_deployment_dir: Path):
+    """Error on create command with wrong copy-conf path."""
+    res = runner.invoke(
+        cli.app, ['create', str(empty_deployment_dir), "--copy-conf", "none.toml"]
+    )
+    assert res.exit_code == 1
+    assert "Config file to copy does not exist" in res.output


### PR DESCRIPTION
This will replace the functions related to `deployments.json`
with a function that checks if a specified path is a deployment, that is:
- has a 'config.toml' file
- has a 'channels' directory
- the database specified in the config file exists.

The database existence check is performed via sqlalchemy_utils.

`quetz create` has a new `delete` option instead of the delete confirmation,
and only works if either `copy_conf` or `create_conf` is specified.
`skip_if_exists` is renamed to `exists_ok`, also.

`config_file_name` is removed from both `run` and `create` commands,
`config.toml` is the only allowed config file name.
file specified in `copy_conf` will be renamed to `config.toml` in the deployment directory.

Pathlib objects are used extensively.
we also use a context manager `working_directory`
to ensure we return to the original folder after the run.

closes #216