### PR TITLE
make github login optional, frontend login buttons

### DIFF
--- a/quetz/config.py
+++ b/quetz/config.py
@@ -71,6 +71,7 @@ class Config:
                 ConfigEntry("client_id", str),
                 ConfigEntry("client_secret", str),
             ],
+            required=False,
         ),
         ConfigSection("sqlalchemy", [ConfigEntry("database_url", str)]),
         ConfigSection(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -66,8 +66,6 @@ from .condainfo import CondaInfo
 app = FastAPI()
 
 config = Config()
-auth_github.register(config)
-
 
 configure_logger(config)
 
@@ -114,7 +112,9 @@ plugin_routers = pm.hook.register_router()
 pkgstore = config.get_package_store()
 pkgstore_support_url = hasattr(pkgstore, 'url')
 
-app.include_router(auth_github.router)
+if config.configured_section("github"):
+    auth_github.register(config)
+    app.include_router(auth_github.router)
 
 for router in plugin_routers:
     app.include_router(router)

--- a/quetz/tests/test_auth_github.py
+++ b/quetz/tests/test_auth_github.py
@@ -131,8 +131,7 @@ def test_config_create_default_channel_exists(client, db, oauth_server, channel)
 
 @pytest.fixture
 def user(dao: Dao):
-    user = dao.create_user_with_role("existing_user", role=SERVER_OWNER)
-    return user
+    return dao.create_user_with_role("existing_user", role=SERVER_OWNER)
 
 
 @pytest.mark.parametrize("default_role", ["member", "maintainer", "owner", None])
@@ -157,7 +156,7 @@ def test_config_user_exists(
 
     assert new_user
     assert new_user.username == login
-    assert not login == "existing_user" or new_user.role == SERVER_OWNER
+    assert login != "existing_user" or new_user.role == SERVER_OWNER
     assert login == "existing_user" or new_user.role == default_role
     assert new_user.profile
     assert new_user.identities

--- a/quetz_frontend/src/components/Header.vue
+++ b/quetz_frontend/src/components/Header.vue
@@ -14,17 +14,17 @@
         <img class="avatar-img" :src="avatar_url"  />
       </template>
       <template v-else>
-        <cv-button v-on:click="signinGithub">
-          Sign In Via Github
-        </cv-button>
-<!--
-        <cv-button v-on:click="signinGoogle">
-          Sign In Via Google
-        </cv-button>
- -->
+        <template v-if="github_login">
+          <cv-button v-on:click="signinGithub">
+            Sign In Via Github
+          </cv-button>
+        </template>
+        <template v-if="google_login">
+          <cv-button v-on:click="signinGoogle">
+            Sign In Via Google
+          </cv-button>
+        </template>
         <cv-header-global-action aria-label="User avatar" aria-controls="user-panel">
-        <!-- <img :src="avatar_url" v-if="avatar_url" /> -->
-
         <UserAvatar20 />
       </cv-header-global-action>
       </template>
@@ -59,11 +59,16 @@
         yourName: '',
         visible: false,
         name: '',
-        avatar_url: undefined
+        avatar_url: undefined,
+        github_login: false,
+        google_login: false,
       };
     },
     created() {
       this.me();
+      this.check_github_login();
+      this.check_google_login();
+    //  TODO: get enabled login routes
     },
     methods: {
       signinGithub() {
@@ -89,7 +94,22 @@
             this.name = '';
             this.avatar_url = undefined;
           }
-
+        })
+      },
+      check_github_login() {
+        fetch("/auth/github/enabled").then((msg) => {
+          this.github_login = msg.status === 200;
+        }).catch((err) => {
+          console.log(err);
+          this.github_login = false;
+        })
+      },
+      check_google_login() {
+        fetch("/auth/google/enabled").then((msg) => {
+          this.google_login = msg.status === 200;
+        }).catch((err) => {
+          console.log(err);
+          this.google_login = false;
         })
       },
       onClick() {


### PR DESCRIPTION
- the github part of the config is now optional;
- two new test endpoint to check if the google/github auth is enabled;
- Vue frontend checks for these endpoints to show the login buttons;
- using the router prefix instead of declaring the full path for each entrypoint
- minor refactors

I'm sorry I didn't add unit tests, but I cannot wrap my head around the config object...  How do I create a test config with the google entries (and without the github ones)?