### PR TITLE
generate alphanumeric api keys

### DIFF
--- a/quetz/main.py
+++ b/quetz/main.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import sys
 import traceback
 import uuid
@@ -67,7 +66,7 @@ from quetz.rest_models import ChannelActionEnum, CPRole
 from quetz.tasks import indexing
 from quetz.tasks.common import Task
 from quetz.tasks.mirror import LocalCache, RemoteRepository, get_from_cache_or_download
-from quetz.utils import TicToc
+from quetz.utils import TicToc, generate_random_key
 
 from .condainfo import CondaInfo
 
@@ -840,7 +839,7 @@ def post_api_key(
 
     user_id = auth.assert_user()
 
-    key = secrets.token_urlsafe(32)
+    key = generate_random_key(32)
     dao.create_api_key(user_id, api_key, key)
 
     return rest_models.ApiKey(

--- a/quetz/tests/api/test_api_keys.py
+++ b/quetz/tests/api/test_api_keys.py
@@ -3,6 +3,7 @@ import pytest
 from quetz.dao import Dao
 from quetz.db_models import ApiKey, ChannelMember, PackageMember
 from quetz.rest_models import BaseApiKey
+from quetz.utils import generate_random_key
 
 
 @pytest.fixture
@@ -196,3 +197,17 @@ def test_unlist_delete_api_keys(auth_client, api_keys, db, private_channel, user
 
     returned_keys = {key["description"]: key["roles"] for key in response.json()}
     assert "key" not in returned_keys
+
+
+@pytest.mark.parametrize("loop", [i + 1 for i in range(100)])
+def test_generate_random_key(loop):
+    key = generate_random_key()
+    assert len(key) == 32
+    assert key.isalnum()
+
+
+@pytest.mark.parametrize("length", [i + 1 for i in range(100)])
+def test_generate_random_key_variable_length(length):
+    key = generate_random_key(length)
+    assert len(key) == length
+    assert key.isalnum()

--- a/quetz/utils.py
+++ b/quetz/utils.py
@@ -4,6 +4,8 @@
 import bz2
 import gzip
 import hashlib
+import secrets
+import string
 import time
 from datetime import datetime, timezone
 
@@ -59,3 +61,8 @@ class TicToc:
     @property
     def elapsed(self):
         return self.stop - self.start
+
+
+def generate_random_key(length=32):
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for i in range(length))


### PR DESCRIPTION
closes #231

Please note that the key format is not validated in `ApiKey` db or rest model in order to not break existing tests and old keys.