### PR TITLE
adding query syntax

### DIFF
--- a/plugins/quetz_transmutation/quetz_transmutation/api.py
+++ b/plugins/quetz_transmutation/quetz_transmutation/api.py
@@ -12,6 +12,8 @@ from quetz.deps import get_db, get_rules
 from quetz.jobs.models import Job
 from quetz.pkgstores import PackageStore
 
+from .rest_models import PackageSpec
+
 router = APIRouter()
 
 
@@ -59,11 +61,17 @@ def transmutation(package_version: dict, config, pkgstore: PackageStore, dao: Da
 transmutation_serialized = pickle.dumps(transmutation)
 
 
-@router.get("/api/transmutation")
+@router.put("/api/transmutation")
 def put_transmutation(
-    db=Depends(get_db), auth: authorization.Rules = Depends(get_rules)
+    package_spec: PackageSpec,
+    db=Depends(get_db),
+    auth: authorization.Rules = Depends(get_rules),
 ):
     user = auth.get_user()
-    job = Job(owner_id=user, manifest=transmutation_serialized)
+    job = Job(
+        owner_id=user,
+        manifest=transmutation_serialized,
+        items_spec=package_spec.package_spec,
+    )
     db.add(job)
     db.commit()

--- a/quetz/jobs/models.py
+++ b/quetz/jobs/models.py
@@ -40,6 +40,7 @@ class Job(Base):
     manifest = sa.Column(sa.Binary(), nullable=False)
     owner_id = sa.Column(UUID, sa.ForeignKey('users.id'), nullable=True)
     owner = sa.orm.relationship('User', backref=sa.orm.backref('jobs'))
+    item_specs = sa.Column(sa.String(), nullable=True)
     items = sa.Column(
         sa.Enum(ItemsSelection),
         nullable=False,

--- a/quetz/jobs/models.py
+++ b/quetz/jobs/models.py
@@ -40,7 +40,7 @@ class Job(Base):
     manifest = sa.Column(sa.Binary(), nullable=False)
     owner_id = sa.Column(UUID, sa.ForeignKey('users.id'), nullable=True)
     owner = sa.orm.relationship('User', backref=sa.orm.backref('jobs'))
-    item_specs = sa.Column(sa.String(), nullable=True)
+    items_spec = sa.Column(sa.String(), nullable=True)
     items = sa.Column(
         sa.Enum(ItemsSelection),
         nullable=False,

--- a/quetz/migrations/versions/794249a0b1bd_adding_jobs_tables.py
+++ b/quetz/migrations/versions/794249a0b1bd_adding_jobs_tables.py
@@ -24,6 +24,7 @@ def upgrade():
         sa.Column('updated', sa.DateTime(), nullable=False),
         sa.Column('manifest', sa.Binary(), nullable=False),
         sa.Column('owner_id', sa.LargeBinary(length=16), nullable=True),
+        sa.Column("items_spec", sa.String(), nullable=True),
         sa.Column(
             'items',
             sa.Enum('watch', 'watch_for', 'all', 'list', name='itemsselection'),

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -261,6 +261,31 @@ def test_parse_conda_spec():
         {"version": ("gte", "0.1.2"), "package_name": ("eq", "my-package")},
     ]
 
+    dict_spec = parse_conda_spec("my-package-v2==0.1")
+    assert dict_spec == [
+        {"version": ("eq", "0.1"), "package_name": ("eq", "my-package-v2")},
+    ]
+
+    dict_spec = parse_conda_spec("my-package>=0.1.2,<0.2")
+    assert dict_spec == [
+        {
+            "version": ("and", ("gte", "0.1.2"), ("lt", "0.2")),
+            "package_name": ("eq", "my-package"),
+        },
+    ]
+
+    dict_spec = parse_conda_spec("my-package>=0.1.2,<0.2,other-package==1.1")
+    assert dict_spec == [
+        {
+            "version": ("and", ("gte", "0.1.2"), ("lt", "0.2")),
+            "package_name": ("eq", "my-package"),
+        },
+        {
+            "version": ("eq", "1.1"),
+            "package_name": ("eq", "other-package"),
+        },
+    ]
+
 
 @pytest.mark.parametrize(
     "spec,n_tasks",


### PR DESCRIPTION
Needs some extra testing!

Example package spec:

```
"my-package>=0.1.2,<0.2,other-package==1.1"
```

which will run the job for packages:
* `my-package` with version between 0.1.2 and 0.2
* `other-package` in version 1.1

Note OR (`|`) not yet supported.

### Reference implementations
* conda:
- MatchSpec (docstring): https://github.com/conda/conda/blob/aed799b56d9ee16a3653928527e2af6e41394e85/conda/models/match_spec.py#L73
- parsing: https://github.com/conda/conda/blob/aed799b56d9ee16a3653928527e2af6e41394e85/conda/models/match_spec.py#L569
- conda docs: https://github.com/conda/conda/blob/aed799b56d9ee16a3653928527e2af6e41394e85/docs/source/user-guide/concepts/pkg-specs.rst#package-match-specifications

* PEP440: https://www.python.org/dev/peps/pep-0440/#version-scheme