### PR TITLE
write to tempdir before moving repodata to final destination

### DIFF
--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/main.py
@@ -33,9 +33,7 @@ def register_router():
 
 
 @quetz.hookimpl
-def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
-):
+def post_package_indexing(tempdir, channel_name, subdirs, files, packages):
     for subdir in subdirs:
         fname = f"{channel_name}.{subdir}.map"
         try:

--- a/plugins/quetz_current_repodata/quetz_current_repodata/main.py
+++ b/plugins/quetz_current_repodata/quetz_current_repodata/main.py
@@ -1,29 +1,28 @@
 import json
+from pathlib import Path
 
 from conda_build.index import _build_current_repodata
 
 import quetz
-from quetz.utils import add_static_file
+from quetz.utils import add_temp_static_file
 
 
 @quetz.hookimpl
-def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore", channel_name, subdirs, files, packages
-):
+def post_package_indexing(tempdir: Path, channel_name, subdirs, files, packages):
     pins = {}
     for subdir in subdirs:
-        f = pkgstore.serve_path(channel_name, f"{subdir}/repodata.json")
-        repodata = json.load(f)
+        with open(tempdir / channel_name / subdir / "repodata.json") as f:
+            repodata = json.load(f)
 
         current_repodata = _build_current_repodata(subdir, repodata, pins)
 
         current_repodata_string = json.dumps(current_repodata, indent=2, sort_keys=True)
 
-        add_static_file(
+        add_temp_static_file(
             current_repodata_string,
             channel_name,
             subdir,
             "current_repodata.json",
-            pkgstore,
+            tempdir,
             files,
         )

--- a/quetz/hooks.py
+++ b/quetz/hooks.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import BinaryIO, List, Optional
 
 import fastapi
@@ -34,7 +35,7 @@ def post_add_package_version(
 
 @hookspec
 def post_package_indexing(
-    pkgstore: "quetz.pkgstores.PackageStore",
+    tempdir: Path,
     channel_name: str,
     subdirs: List[str],
     files: dict,


### PR DESCRIPTION
This should make our repodata updates safer, and also make sure that we don't have unpatched repodata in the final destination. 

@btel do you have any remarks?