### PR TITLE
fill db from channeldata/repodata

### DIFF
--- a/docs/source/using/mirroring.rst
+++ b/docs/source/using/mirroring.rst
@@ -104,7 +104,7 @@ If packages are added or modified on the primary server from which they were pul
 
    curl -X PUT localhost:8000/api/channels/mirror-channel/actions \ 
        -H "X-API-Key: ${QUETZ_API_KEY}" \
-       -d '{"action": "synchronize"}'
+       -d '{"action": "synchronize_repodata"}'
 
 Only channel owners or maintainers are allowed to trigger synchronisation, therefore you have to provide a valid API key of a privileged user.
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
   - requests
   - h2<4.0.0
   - pluggy
-  - starlette-full
   - jinja2
   - itsdangerous
   - alembic
@@ -33,3 +32,6 @@ dependencies:
   - sphinx-book-theme
   - tenacity
   - xattr
+  - aiofiles
+  - pyyaml
+  - ujson

--- a/quetz/condainfo.py
+++ b/quetz/condainfo.py
@@ -63,6 +63,18 @@ def calculate_file_hashes_and_size(info, file):
     info["sha256"] = sha.hexdigest()
 
 
+def get_subdir_compat(info):
+    "compatibility layer for subdir property of packages"
+
+    subdir = info.get("subdir", None)
+    if not subdir:
+        arch = info["arch"]
+        platform = info["platform"]
+        if arch == "x86_64":
+            subdir = platform + '-64'
+    return subdir
+
+
 class CondaInfo:
     def __init__(self, file, filename):
         self.channeldata = {}
@@ -128,13 +140,7 @@ class CondaInfo:
     def _load_jsons(self, tar):
         self.info = json.load(tar.extractfile("info/index.json"))
 
-        subdir = self.info.get("subdir", None)
-        if not subdir:
-            arch = self.info["arch"]
-            platform = self.info["platform"]
-            if arch == "x86_64":
-                subdir = platform + '-64'
-            self.info['subdir'] = subdir
+        self.info['subdir'] = get_subdir_compat(self.info)
 
         try:
             self.about = json.load(tar.extractfile("info/about.json"))

--- a/quetz/condainfo.py
+++ b/quetz/condainfo.py
@@ -76,7 +76,7 @@ def get_subdir_compat(info):
 
 
 class CondaInfo:
-    def __init__(self, file, filename):
+    def __init__(self, file, filename, lazy=False):
         self.channeldata = {}
         self.package_format = None
         self._file = file
@@ -85,12 +85,13 @@ class CondaInfo:
             self.package_format = db_models.PackageFormatEnum.conda
         else:
             self.package_format = db_models.PackageFormatEnum.tarbz2
+        if not lazy:
+            self._parse_conda()
 
     def __getattr__(self, name):
         # lazily extract the conda info from package files
         if name in ["info", "about", "paths", "run_exports", "files"]:
             self._parse_conda()
-            self._parsed = True
         return getattr(self, name)
 
     def _map_channeldata(self):

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -536,7 +536,7 @@ def post_channel(
 
     if new_channel.metadata.actions is None:
         if is_mirror:
-            actions = [ChannelActionEnum.synchronize]
+            actions = [ChannelActionEnum.synchronize_repodata]
         else:
             actions = []
     else:
@@ -584,12 +584,9 @@ def post_channel(
             logger.warning(f"could not register mirror due to error {response.text}")
 
     for action in actions:
-        if action == ChannelActionEnum.synchronize:
-            task.execute_channel_action(
-                action, channel, includelist=includelist, excludelist=excludelist
-            )
-        else:
-            task.execute_channel_action(action, channel)
+        task.execute_channel_action(
+            action, channel, includelist=includelist, excludelist=excludelist
+        )
 
 
 @api_router.patch(

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -87,6 +87,7 @@ class ChannelBase(BaseModel):
 
 class ChannelActionEnum(str, Enum):
     synchronize = 'synchronize'
+    synchronize_repodata = "synchronize_repodata"
     reindex = 'reindex'
     generate_indexes = 'generate_indexes'
     validate_packages = 'validate_packages'

--- a/quetz/tasks/common.py
+++ b/quetz/tasks/common.py
@@ -61,6 +61,17 @@ class Task:
                 includelist=includelist,
                 excludelist=excludelist,
             )
+        elif action == ChannelActionEnum.synchronize_repodata:
+            auth.assert_synchronize_mirror(channel_name)
+            includelist = kwargs.get('includelist')
+            excludelist = kwargs.get('excludelist')
+            self.worker.execute(
+                mirror.synchronize_packages,
+                channel_name=channel_name,
+                use_repodata=True,
+                includelist=includelist,
+                excludelist=excludelist,
+            )
         elif action == ChannelActionEnum.validate_packages:
             auth.assert_validate_package_cache(channel_name)
             self.worker.execute(indexing.validate_packages, channel_name=channel.name)

--- a/quetz/tasks/common.py
+++ b/quetz/tasks/common.py
@@ -15,6 +15,8 @@ logger = logging.getLogger("quetz")
 def assert_channel_action(action, channel):
     if action == ChannelActionEnum.synchronize:
         action_allowed = assertions.can_channel_synchronize(channel)
+    elif action == ChannelActionEnum.synchronize_repodata:
+        action_allowed = assertions.can_channel_synchronize(channel)
     elif action == ChannelActionEnum.validate_packages:
         action_allowed = assertions.can_channel_validate_package_cache(channel)
     elif action == ChannelActionEnum.generate_indexes:

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -6,12 +6,11 @@ import shutil
 from concurrent.futures import ThreadPoolExecutor
 from http.client import IncompleteRead
 from tempfile import SpooledTemporaryFile
-from typing import List
 
 import requests
 from fastapi import HTTPException, status
 from fastapi.responses import FileResponse, StreamingResponse
-from tenacity import after_log, retry, stop_after_attempt, wait_exponential
+from tenacity import TryAgain, after_log, retry, stop_after_attempt, wait_exponential
 
 from quetz import authorization, rest_models
 from quetz.config import Config
@@ -20,6 +19,7 @@ from quetz.db_models import Channel, PackageVersion
 from quetz.pkgstores import PackageStore
 from quetz.tasks import indexing
 from quetz.utils import check_package_membership
+from quetz.utils import TicToc
 
 # copy common subdirs from conda:
 # https://github.com/conda/conda/blob/a78a2387f26a188991d771967fc33aa1fb5bb810/conda/base/constants.py#L63
@@ -241,7 +241,8 @@ def _check_checksum(dao: Dao, channel_name: str, platform: str, keyname="sha256"
     wait=wait_exponential(multiplier=1, min=4, max=10),
     after=after_log(logger, logging.WARNING),
 )
-def download_file(remote_repository, path):
+def download_file(remote_repository, path_metadata):
+    path, package_name, metadata = path_metadata
     try:
         f = remote_repository.open(path)
     except RemoteServerError as e:
@@ -252,7 +253,78 @@ def download_file(remote_repository, path):
         raise e
 
     logger.debug(f"Fetched file {path}")
-    return f
+    return f, package_name, metadata
+
+
+def handle_repodata_package(
+    channel_name,
+    files_metadata,
+    dao,
+    auth,
+    force,
+    pkgstore,
+    config,
+):
+    user_id = auth.assert_user()
+
+    total_size = 0
+    for file, package_name, metadata in files_metadata:
+        parts = file.filename.rsplit("-", 2)
+        if len(parts) != 3:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"package file name has wrong format {file.filename}",
+            )
+        else:
+            package_name = parts[0]
+        auth.assert_upload_file(channel_name, package_name)
+        if force:
+            auth.assert_overwrite_package_version(channel_name, package_name)
+
+        # workaround for https://github.com/python/cpython/pull/3249
+        if type(file.file) is SpooledTemporaryFile and not hasattr(file, "seekable"):
+            file.file.seekable = file.file._file.seekable
+
+        file.file.seek(0, os.SEEK_END)
+        size = file.file.tell()
+        total_size += size
+        file.file.seek(0)
+
+    dao.assert_size_limits(channel_name, total_size)
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        after=after_log(logger, logging.WARNING),
+    )
+    def _upload_package(file, channel_name, subdir):
+
+        dest = os.path.join(subdir, file.filename)
+
+        try:
+            file.file.seek(0)
+            logger.debug(
+                f"uploading file {dest} from channel {channel_name} to package store"
+            )
+            pkgstore.add_package(file.file, channel_name, dest)
+
+        except AttributeError as e:
+            logger.error(f"Could not upload {file}, {file.filename}. {str(e)}")
+            raise TryAgain
+
+    pkgstore.create_channel(channel_name)
+    nthreads = config.general_package_unpack_threads
+
+    with TicToc("upload file without extracting"):
+        with ThreadPoolExecutor(max_workers=nthreads) as executor:
+            for file, package_name, metadata in files_metadata:
+                executor.submit(_upload_package, file, channel_name, metadata['subdir'])
+
+    with TicToc("add versions to the db"):
+        for file, package_name, metadata in files_metadata:
+            create_version_from_metadata(
+                channel_name, user_id, package_name, metadata, dao
+            )
 
 
 def initial_sync_mirror(
@@ -265,6 +337,7 @@ def initial_sync_mirror(
     includelist: List[str] = None,
     excludelist: List[str] = None,
     skip_errors: bool = True,
+    use_repodata: bool = False,
 ):
 
     force = True  # needed for updating packages
@@ -327,6 +400,7 @@ def initial_sync_mirror(
                 return False
 
             remote_packages = []
+            remote_packages_with_metadata = []
 
             with ThreadPoolExecutor(
                 max_workers=config.mirroring_num_parallel_downloads
@@ -337,16 +411,29 @@ def initial_sync_mirror(
                     update_batch,
                 ):
                     if f is not None:
-                        remote_packages.append(f)
+                        remote_packages.append(f[0])
+                        remote_packages_with_metadata.append(f)
 
             try:
-                handle_package_files(
-                    channel_name,
-                    remote_packages,
-                    dao,
-                    auth,
-                    force,
-                )
+                if use_repodata:
+                    handle_repodata_package(
+                        channel_name,
+                        remote_packages_with_metadata,
+                        dao,
+                        auth,
+                        force,
+                        pkgstore,
+                        config,
+                    )
+
+                else:
+                    handle_package_files(
+                        channel_name,
+                        remote_packages,
+                        dao,
+                        auth,
+                        force,
+                    )
                 return True
 
             except Exception as exc:
@@ -378,8 +465,13 @@ def initial_sync_mirror(
                 else:
                     logger.debug(f"updating package {package_name} from {arch}")
 
+<<<<<<< HEAD
                 update_batch.append(path)
                 update_size += metadata.get('size', 100_000)
+=======
+            update_batch.append((path, package_name, metadata))
+            update_size += metadata.get('size', 100_000)
+>>>>>>> 8440c0e (handle mirrors with repodata)
 
             if len(update_batch) >= max_batch_length or update_size >= max_batch_size:
                 logger.debug(f"Executing batch with {update_size}")
@@ -397,7 +489,7 @@ def initial_sync_mirror(
 def create_packages_from_channeldata(
     channel_name: str, user_id: bytes, channeldata: dict, dao: Dao
 ):
-    packages = channeldata["packages"]
+    packages = channeldata.get("packages", {})
 
     for package_name, metadata in packages.items():
         package_data = rest_models.Package(
@@ -413,36 +505,36 @@ def create_packages_from_channeldata(
         dao.db.commit()
 
 
+def create_version_from_metadata(
+    channel_name: str, user_id: bytes, package_name: str, package_data: dict, dao: Dao
+):
+
+    pkg_format = "tarbz2" if package_name.endswith(".tar.bz2") else ".conda"
+
+    version = dao.create_version(
+        channel_name,
+        package_data["name"],
+        pkg_format,
+        package_data["subdir"],
+        package_data["version"],
+        int(package_data["build_number"]),
+        package_data["build"],
+        package_name,
+        json.dumps(package_data),
+        user_id,
+        package_data["size"],
+    )
+
+    # pm.hook.post_add_package_version(version=version, condainfo=condainfo)
+    return version
+
+
 def create_versions_from_repodata(
     channel_name: str, user_id: bytes, repodata: dict, dao: Dao
 ):
-    packages: Dict[str, dict] = repodata["packages"]
-
+    packages = repodata.get("packages", {})
     for filename, metadata in packages.items():
-        pkg_format = "tarbz2" if filename.endswith(".tar.bz2") else ".conda"
-        dao.create_version(
-            channel_name,
-            metadata["name"],
-            pkg_format,
-            metadata["subdir"],
-            metadata["version"],
-            int(metadata["build_number"]),
-            metadata["build"],
-            filename,
-            json.dumps(metadata),
-            user_id,
-            metadata["size"],
-        )
-
-
-def fill_db_from_index(
-    channel_name: str,
-    user_id: bytes,
-    channel_url: str,
-    session: requests.Session,
-    dao: Dao,
-):
-    pass
+        create_version_from_metadata(channel_name, user_id, filename, metadata, dao)
 
 
 def synchronize_packages(
@@ -462,8 +554,12 @@ def synchronize_packages(
     host = new_channel.mirror_channel_url
 
     remote_repo = RemoteRepository(new_channel.mirror_channel_url, session)
+
+    user_id = auth.assert_user()
+
     try:
         channel_data = remote_repo.open("channeldata.json").json()
+        create_packages_from_channeldata(channel_name, user_id, channel_data, dao)
         subdirs = channel_data.get("subdirs", [])
     except (RemoteFileNotFound, json.JSONDecodeError):
         subdirs = None

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -329,7 +329,7 @@ def handle_repodata_package(
             version = create_version_from_metadata(
                 channel_name, user_id, package_name, metadata, dao
             )
-            condainfo = CondaInfo(file, package_name)
+            condainfo = CondaInfo(file, package_name, lazy=True)
             pm.hook.post_add_package_version(version=version, condainfo=condainfo)
 
 

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -6,6 +6,7 @@ import shutil
 from concurrent.futures import ThreadPoolExecutor
 from http.client import IncompleteRead
 from tempfile import SpooledTemporaryFile
+from typing import List
 
 import requests
 from fastapi import HTTPException, status
@@ -18,8 +19,7 @@ from quetz.dao import Dao
 from quetz.db_models import Channel, PackageVersion
 from quetz.pkgstores import PackageStore
 from quetz.tasks import indexing
-from quetz.utils import check_package_membership
-from quetz.utils import TicToc
+from quetz.utils import TicToc, check_package_membership
 
 # copy common subdirs from conda:
 # https://github.com/conda/conda/blob/a78a2387f26a188991d771967fc33aa1fb5bb810/conda/base/constants.py#L63
@@ -465,13 +465,8 @@ def initial_sync_mirror(
                 else:
                     logger.debug(f"updating package {package_name} from {arch}")
 
-<<<<<<< HEAD
-                update_batch.append(path)
+                update_batch.append((path, package_name, metadata))
                 update_size += metadata.get('size', 100_000)
-=======
-            update_batch.append((path, package_name, metadata))
-            update_size += metadata.get('size', 100_000)
->>>>>>> 8440c0e (handle mirrors with repodata)
 
             if len(update_batch) >= max_batch_length or update_size >= max_batch_size:
                 logger.debug(f"Executing batch with {update_size}")
@@ -545,6 +540,7 @@ def synchronize_packages(
     session: requests.Session,
     includelist: List[str] = None,
     excludelist: List[str] = None,
+    use_repodata: bool = False,
 ):
 
     logger.debug(f"executing synchronize_packages task in a process {os.getpid()}")
@@ -582,4 +578,5 @@ def synchronize_packages(
             auth,
             includelist,
             excludelist,
+            use_repodata=use_repodata,
         )

--- a/quetz/tests/api/test_channels.py
+++ b/quetz/tests/api/test_channels.py
@@ -306,6 +306,7 @@ def test_upload_package_version_to_channel(
 
     with open(package_filename, "rb") as fid:
         condainfo = CondaInfo(fid, package_filename)
+        condainfo._parse_conda()
 
     assert response.status_code == 201
     db.refresh(public_channel)

--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -244,6 +244,7 @@ def test_upload_package_version(
 
     with open(package_filename, "rb") as fid:
         condainfo = CondaInfo(fid, package_filename)
+        condainfo._parse_conda()
 
     if package_name == "my-package":
         assert response.status_code == 400
@@ -382,6 +383,7 @@ def test_validate_package_names_files_endpoint(
 
     with open(package_filename, "rb") as fid:
         condainfo = CondaInfo(fid, package_filename)
+        condainfo._parse_conda()
 
     # patch conda info
     condainfo.info['name'] = package_name

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -903,7 +903,9 @@ def test_sync_mirror_channel(mirror_channel, user, client, dummy_repo):
     "package_list_type, expected_package",
     [("includelist", "nrnpython"), ("excludelist", "test-package")],
 )
-def test_packagelist_mirror_channel(owner, client, package_list_type, expected_package):
+def test_packagelist_mirror_channel(
+    owner, client, package_list_type, expected_package, db
+):
     response = client.get("/api/dummylogin/bartosz")
     assert response.status_code == 200
 

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -1097,6 +1097,8 @@ def rules(user, db):
 def test_handle_repodata_package(
     dao, user, local_channel, dummy_package_file, rules, config, db
 ):
+    pkg = Package(name="other-package", channel=local_channel)
+    db.add(pkg)
 
     repodata = json.loads(repodata_json)
     package_name, package_data = list(repodata["packages"].items())[0]

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -1071,7 +1071,7 @@ def test_create_versions_from_repodata(dao, user, local_channel, db):
 
 
 @pytest.fixture
-def dummy_package_file():
+def dummy_package_file(config):
 
     filepath = OTHER_DUMMY_PACKAGE_V2
     fid = open(filepath, 'rb')


### PR DESCRIPTION
use `synchronize_repodata` action to trigger synchronisation based on repodata (no extraction of tarballs required). it's also a default when creating a new mirror channel.