### PR TITLE
re-running job on new package versions

### DIFF
--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, validator
 
 from quetz import authorization
 from quetz.dao import Dao
-from quetz.deps import get_dao, get_rules
+from quetz.deps import get_dao, get_db, get_rules
 from quetz.jobs import models as job_db_models
 from quetz.rest_models import User
 
@@ -94,6 +94,18 @@ def get_tasks(
 ):
     auth.assert_jobs()
     return job.tasks
+
+
+@api_router.put("/api/jobs/{job_id}", tags=["Jobs"])
+def put_job(
+    db=Depends(get_db),
+    job: job_db_models.Job = Depends(get_job_or_fail),
+    auth: authorization.Rules = Depends(get_rules),
+):
+    """refresh job (re-run on new packages)"""
+    auth.assert_jobs()
+    job.status = JobStatus.pending  # type: ignore
+    db.commit()
 
 
 def get_router():

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -136,6 +136,7 @@ def run_jobs(db):
         else:
             logger.warning("empty package spec returns no results")
             q = []
+
         task = None
         for version in q:
             task = Task(job=job, package_version=version)

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -31,7 +31,9 @@ def channel_name():
     return "my-channel"
 
 
-def add_package_version(filename, channel_name, user, dao, package_name=None):
+def add_package_version(
+    filename, package_version, channel_name, user, dao, package_name=None
+):
 
     if not package_name:
         package_name = "test-package"
@@ -44,7 +46,7 @@ def add_package_version(filename, channel_name, user, dao, package_name=None):
         package_name,
         package_format,
         "linux-64",
-        "0.1",
+        package_version,
         0,
         "",
         path.name,
@@ -70,7 +72,9 @@ def package_version(
     pkgstore = config.get_package_store()
 
     filename = "test-package-0.1-0.tar.bz2"
-    version = add_package_version(filename, channel_name, user, dao, package_name)
+    version = add_package_version(
+        filename, "0.1", channel_name, user, dao, package_name
+    )
     path = Path(filename)
     with open(path, "rb") as fid:
         pkgstore.add_file(fid.read(), channel_name, "linux-64" / path)
@@ -178,7 +182,7 @@ async def test_create_job(db, user, package_version, manager):
 
 @pytest.mark.asyncio
 async def test_run_tasks_only_on_new_versions(
-    db, user, package_version, manager, dao, channel_name
+    db, user, package_version, manager, dao, channel_name, package_name
 ):
 
     func_serialized = pickle.dumps(dummy_func)
@@ -207,7 +211,7 @@ async def test_run_tasks_only_on_new_versions(
     assert job.status == JobStatus.success
 
     filename = "test-package-0.2-0.tar.bz2"
-    add_package_version(filename, channel_name, user, dao)
+    add_package_version(filename, "0.2", channel_name, user, dao, package_name)
 
     job.status = JobStatus.pending
     db.commit()


### PR DESCRIPTION
adding PUT /jobs/{} endpoint to run the job on new packages.

re-running on all packages (the processed ones included) is not yet implemented, but it could be done if a new job with the same specs is created.