### PR TITLE
create any jobs from /jobs endpoint

### DIFF
--- a/plugins/quetz_transmutation/quetz_transmutation/api.py
+++ b/plugins/quetz_transmutation/quetz_transmutation/api.py
@@ -1,83 +1,17 @@
-import json
 import logging
-import os
 import pickle
-import shutil
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
-from conda_package_handling.api import _convert
 from fastapi import APIRouter, Depends
 
 from quetz import authorization
-from quetz.condainfo import calculate_file_hashes_and_size
-from quetz.dao import Dao
 from quetz.deps import get_db, get_rules
 from quetz.jobs.models import Job
-from quetz.pkgstores import PackageStore
 
+from .jobs import transmutation
 from .rest_models import PackageSpec
 
 router = APIRouter()
-logger = logging.getLogger("quetz-cli")
-
-
-def transmutation(package_version: dict, config, pkgstore: PackageStore, dao: Dao):
-    filename: str = package_version["filename"]
-    channel: str = package_version["channel_name"]
-    package_format: str = package_version["package_format"]
-    package_name: str = package_version["package_name"]
-    platform = package_version["platform"]
-    version = package_version["version"]
-    build_number = package_version["build_number"]
-    build_string = package_version["build_string"]
-    uploader_id = package_version["uploader_id"]
-    info = json.loads(package_version["info"])
-
-    if package_format == "tarbz2" or not filename.endswith(".tar.bz2"):
-        return
-
-    fh = pkgstore.serve_path(channel, Path(platform) / filename)
-
-    with TemporaryDirectory() as tmpdirname:
-        local_file_name = os.path.join(tmpdirname, filename)
-        with open(local_file_name, "wb") as local_file:
-            # chunk size 10MB
-            shutil.copyfileobj(fh, local_file, 10 * 1024 * 1024)
-
-        fn, out_fn, errors = _convert(local_file_name, ".conda", tmpdirname, force=True)
-
-        if errors:
-            logger.error(f"transmutation errors --> {errors}")
-            return
-
-        filename_conda = os.path.basename(filename).replace('.tar.bz2', '.conda')
-
-        logger.info(f"Adding file to package store: {Path(platform) / filename_conda}")
-
-        with open(out_fn, 'rb') as f:
-            calculate_file_hashes_and_size(info, f)
-            f.seek(0)
-            pkgstore.add_package(f, channel, Path(platform) / filename_conda)
-
-        version = dao.create_version(
-            channel,
-            package_name,
-            "conda",
-            platform,
-            version,
-            build_number,
-            build_string,
-            filename_conda,
-            json.dumps(info),
-            uploader_id,
-            info["size"],
-            upsert=True,
-        )
-
-        if os.path.exists(out_fn):
-            os.remove(out_fn)
-
+logger = logging.getLogger("quetz-jobs")
 
 transmutation_serialized = pickle.dumps(transmutation)
 

--- a/plugins/quetz_transmutation/quetz_transmutation/api.py
+++ b/plugins/quetz_transmutation/quetz_transmutation/api.py
@@ -11,7 +11,7 @@ from .jobs import transmutation
 from .rest_models import PackageSpec
 
 router = APIRouter()
-logger = logging.getLogger("quetz-jobs")
+logger = logging.getLogger("quetz.jobs")
 
 transmutation_serialized = pickle.dumps(transmutation)
 

--- a/plugins/quetz_transmutation/quetz_transmutation/jobs.py
+++ b/plugins/quetz_transmutation/quetz_transmutation/jobs.py
@@ -1,0 +1,71 @@
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from conda_package_handling.api import _convert
+
+from quetz.condainfo import calculate_file_hashes_and_size
+from quetz.dao import Dao
+from quetz.pkgstores import PackageStore
+
+logger = logging.getLogger("quetz-plugins")
+
+
+def transmutation(package_version: dict, config, pkgstore: PackageStore, dao: Dao):
+    filename: str = package_version["filename"]
+    channel: str = package_version["channel_name"]
+    package_format: str = package_version["package_format"]
+    package_name: str = package_version["package_name"]
+    platform = package_version["platform"]
+    version = package_version["version"]
+    build_number = package_version["build_number"]
+    build_string = package_version["build_string"]
+    uploader_id = package_version["uploader_id"]
+    info = json.loads(package_version["info"])
+
+    if package_format == "tarbz2" or not filename.endswith(".tar.bz2"):
+        return
+
+    fh = pkgstore.serve_path(channel, Path(platform) / filename)
+
+    with TemporaryDirectory() as tmpdirname:
+        local_file_name = os.path.join(tmpdirname, filename)
+        with open(local_file_name, "wb") as local_file:
+            # chunk size 10MB
+            shutil.copyfileobj(fh, local_file, 10 * 1024 * 1024)
+
+        fn, out_fn, errors = _convert(local_file_name, ".conda", tmpdirname, force=True)
+
+        if errors:
+            logger.error(f"transmutation errors --> {errors}")
+            return
+
+        filename_conda = os.path.basename(filename).replace('.tar.bz2', '.conda')
+
+        logger.info(f"Adding file to package store: {Path(platform) / filename_conda}")
+
+        with open(out_fn, 'rb') as f:
+            calculate_file_hashes_and_size(info, f)
+            f.seek(0)
+            pkgstore.add_package(f, channel, str(Path(platform) / filename_conda))
+
+        version = dao.create_version(
+            channel,
+            package_name,
+            "conda",
+            platform,
+            version,
+            build_number,
+            build_string,
+            filename_conda,
+            json.dumps(info),
+            uploader_id,
+            info["size"],
+            upsert=True,
+        )
+
+        if os.path.exists(out_fn):
+            os.remove(out_fn)

--- a/plugins/quetz_transmutation/quetz_transmutation/jobs.py
+++ b/plugins/quetz_transmutation/quetz_transmutation/jobs.py
@@ -11,7 +11,7 @@ from quetz.condainfo import calculate_file_hashes_and_size
 from quetz.dao import Dao
 from quetz.pkgstores import PackageStore
 
-logger = logging.getLogger("quetz-plugins")
+logger = logging.getLogger("quetz.plugins")
 
 
 def transmutation(package_version: dict, config, pkgstore: PackageStore, dao: Dao):

--- a/plugins/quetz_transmutation/setup.py
+++ b/plugins/quetz_transmutation/setup.py
@@ -3,6 +3,9 @@ from setuptools import setup
 setup(
     name="quetz-transmutation",
     install_requires="quetz",
-    entry_points={"quetz": ["quetz-transmutation = quetz_transmutation.main"]},
+    entry_points={
+        "quetz": ["quetz-transmutation = quetz_transmutation.main"],
+        "quetz.jobs": ["quetz-transmutation = quetz_transmutation.jobs"],
+    },
     packages=["quetz_transmutation"],
 )

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -593,6 +593,8 @@ def watch_job_queue(
 ) -> None:
     import time
 
+    configure_logger(loggers=("quetz",))
+
     from quetz.jobs.runner import check_status, run_jobs, run_tasks
     from quetz.tasks.workers import SubprocessWorker
 

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -770,6 +770,7 @@ class Dao:
         )
         self.db.add(job)
         self.db.commit()
+        return job
 
     def incr_download_count(
         self,

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -79,8 +79,8 @@ def get_jobs(
     return dao.get_jobs()
 
 
-@api_router.post("/api/jobs", tags=["Jobs"], status_code=201)
-def post_jobs(
+@api_router.post("/api/jobs", tags=["Jobs"], status_code=201, response_model=Job)
+def create_job(
     job: JobBase,
     dao: Dao = Depends(get_dao),
     auth: authorization.Rules = Depends(get_rules),
@@ -88,7 +88,8 @@ def post_jobs(
     """create a new job"""
     user = auth.assert_user()
     auth.assert_jobs()
-    dao.create_job(user, job.manifest, job.items_spec)
+    new_job = dao.create_job(user, job.manifest, job.items_spec)
+    return new_job
 
 
 def get_job_or_fail(
@@ -121,7 +122,7 @@ def get_tasks(
 
 
 @api_router.patch("/api/jobs/{job_id}", tags=["Jobs"])
-def patch_job(
+def update_job(
     job_data: JobUpdateModel,
     db=Depends(get_db),
     job: job_db_models.Job = Depends(get_job_or_fail),

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -134,7 +134,7 @@ def update_job(
 
     # ignore tasks that have already been run
     if job_data.force:
-        run_jobs(db, force=True)
+        run_jobs(db, job_id=job.id, force=True)
 
     db.commit()
 

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -19,6 +19,7 @@ from quetz.jobs import models as job_db_models
 from quetz.rest_models import User
 
 from .models import JobStatus, TaskStatus
+from .runner import run_jobs
 
 api_router = APIRouter()
 
@@ -129,6 +130,11 @@ def patch_job(
     """refresh job (re-run on new packages)"""
     auth.assert_jobs()
     job.status = job_data.status  # type: ignore
+
+    # ignore tasks that have already been run
+    if job_data.force:
+        run_jobs(db, force=True)
+
     db.commit()
 
 

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -105,8 +105,11 @@ def build_sql_from_package_spec(selector: str):
     return sql_expr
 
 
-def run_jobs(db, force=False):
-    for job in db.query(Job).filter(Job.status == JobStatus.pending):
+def run_jobs(db, job_id=None, force=False):
+    jobs = db.query(Job).filter(Job.status == JobStatus.pending)
+    if job_id:
+        jobs = jobs.filter(Job.id == job_id)
+    for job in jobs:
         job.status = JobStatus.running
         if job.items == ItemsSelection.all:
             if force:

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -175,7 +175,12 @@ def config_dir(home):
 
 
 @fixture
-def config(config_str, config_dir):
+def test_data_dir():
+    return os.path.join(os.path.dirname(quetz.__file__), "tests", "data")
+
+
+@fixture
+def config(config_str, config_dir, test_data_dir):
 
     config_path = os.path.join(config_dir, "config.toml")
     with open(config_path, "w") as fid:
@@ -183,9 +188,8 @@ def config(config_str, config_dir):
     old_dir = os.path.abspath(os.curdir)
     os.chdir(config_dir)
     os.environ["QUETZ_CONFIG_FILE"] = config_path
-    data_dir = os.path.join(os.path.dirname(quetz.__file__), "tests", "data")
-    for filename in os.listdir(data_dir):
-        full_path = os.path.join(data_dir, filename)
+    for filename in os.listdir(test_data_dir):
+        full_path = os.path.join(test_data_dir, filename)
         dest = os.path.join(config_dir, filename)
         if os.path.isfile(full_path):
             shutil.copy(full_path, dest)

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -174,7 +174,7 @@ def config_dir(home):
     shutil.rmtree(path)
 
 
-@fixture
+@fixture(scope="session")
 def test_data_dir():
     return os.path.join(os.path.dirname(quetz.__file__), "tests", "data")
 

--- a/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/PKG-INFO
+++ b/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/PKG-INFO
@@ -1,5 +1,5 @@
 Metadata-Version: 1.0
-Name: dummy-dummy-plugin
+Name: quetz-dummyplugin
 Version: 1.0
 Summary: UNKNOWN
 Home-page: UNKNOWN

--- a/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/PKG-INFO
+++ b/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/PKG-INFO
@@ -1,0 +1,10 @@
+Metadata-Version: 1.0
+Name: dummy-dummy-plugin
+Version: 1.0
+Summary: UNKNOWN
+Home-page: UNKNOWN
+Author: UNKNOWN
+Author-email: UNKNOWN
+License: UNKNOWN
+Description: UNKNOWN
+Platform: UNKNOWN

--- a/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/entry_points.txt
+++ b/quetz/tests/data/dummy-plugin/quetz_dummyplugin-1.0-py3.egg-info/entry_points.txt
@@ -1,0 +1,3 @@
+[quetz.jobs]
+
+quetz-dummyplugin = quetz_dummyplugin.jobs

--- a/quetz/tests/data/dummy-plugin/quetz_dummyplugin/jobs.py
+++ b/quetz/tests/data/dummy-plugin/quetz_dummyplugin/jobs.py
@@ -1,0 +1,2 @@
+def dummy_job(package_version):
+    pass

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -554,6 +554,8 @@ def dummy_plugin(test_data_dir):
     "manifest",
     [
         "dummy_func",
+        "os:listdir",
+        "os.listdir",
         "quetz.dummy_func",
         "quetz-plugin:dummy_func",
         "quetz-dummyplugin:missing_job",

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -518,3 +518,15 @@ def test_refresh_job(auth_client, user, db):
 
     db.refresh(job)
     assert job.status == JobStatus.pending
+
+
+@pytest.mark.parametrize("user_role", ["owner"])
+@pytest.mark.parametrize(
+    "manifest", ["dummy_func", "quetz.dummy_func", "quetz-plugin:dummy_func"]
+)
+def test_post_new_job_manifest_validation(auth_client, user, db, manifest):
+    response = auth_client.post(
+        "/api/jobs", json={"items_spec": "*", "manifest": manifest}
+    )
+    assert response.status_code == 422
+    assert "invalid function" in response.json()['detail']

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -512,7 +512,7 @@ def test_refresh_job(auth_client, user, db):
 
     assert job.status == JobStatus.success
 
-    response = auth_client.put(f"/api/jobs/{job.id}")
+    response = auth_client.patch(f"/api/jobs/{job.id}", json={"status": "pending"})
 
     assert response.status_code == 200
 


### PR DESCRIPTION
you can create a new job, by POST /jobs endpoint. For example, to trigger new transmutation job:

```bash
 curl -X POST localhost:8000/api/jobs \
    -H "X-api-key: ${QUETZ_API_KEY}" \
    -d '{"items_spec": "*", "manifest": "quetz-transmutation:transmutation"}'
```

to run a job on new packages:

```
 curl -X PATCH localhost:8000/api/jobs/1 \
    -H "X-api-key: ${QUETZ_API_KEY}" \
    -d '{"status": "pending"}'
```

to run on all packages (already processed ones and new):

```
 curl -X PATCH localhost:8000/api/jobs/1 \
    -H "X-api-key: ${QUETZ_API_KEY}" \
    -d '{"status": "pending", "force": true}'
```

Note that the runnable jobs need to be exported from plugin using the `quetz.jobs` entry point. This is to prevent an arbitrary function to be run by a malicious request.

see also #294 