### PR TITLE
fix creating users with multiple providers

### DIFF
--- a/dev_config.toml
+++ b/dev_config.toml
@@ -16,4 +16,4 @@ level = "DEBUG"
 file = "quetz.log"
 
 [users]
-admins = ["alice"]
+admins = ["dummy:alice"]

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -42,22 +42,25 @@ Configure default user permissions, creating default channel and super-admin per
 
    [users]
    # users with owner role
-   admins = ["admin_user"]
+   admins = ["github:admin_user"]
    # users with maintainer role
-   maintainers = ["other_user"]
+   maintainers = ["google:other_user"]
    # users with memeber role
-   members = ["some", "random", "name"]
+   members = ["github:some", "github:random", "github:name"]
    # default role assigned to new users
    # leave out if role should be null
    default_role = "member"
    # create a default channel for new users named {username}
    create_default_channel = false
 
-You can use one of the following options to configure privilaged users:
+You can use one of the following options to configure privileged users:
 
 :admins: list of users with super-admin permissions (``owner`` role), default: empty list
 :maintainers: list of users with maintainer permission (``maintainer`` role), default: empty list
 :members: list of standard members (``member`` role), default: empty list
+
+The format of the entries is ``PROVIDER:USERNAME`` where ``PROVIDER`` is the name of one of
+the supported providers (such as ``google`` or ``github``).
 
 For all other users, you can define the default role with the following option:
 

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -161,9 +161,7 @@ def _make_migrations(
 def _init_db(db: Session, config: Config):
     """Initialize the database and add users from config."""
     if config.configured_section("users"):
-        from quetz.dao import Dao
 
-        dao = Dao(db)
         role_map = [
             (config.users_admins, "owner"),
             (config.users_maintainers, "maintainer"),
@@ -172,8 +170,32 @@ def _init_db(db: Session, config: Config):
 
         for users, role in role_map:
             for username in users:
+                try:
+                    provider, username = username.split(":")
+                except ValueError:
+                    # use github as default provider
+                    raise ValueError(
+                        "could not parse the users setting, please provide users in"
+                        "the format 'PROVIDER:USERNAME' where provider is one of"
+                        "'google', 'github', 'dummy', etc."
+                    )
                 logger.info(f"create user {username} with role {role}")
-                dao.create_user_with_role(username, role)
+                user = (
+                    db.query(User)
+                    .join(Identity)
+                    .filter(Identity.provider == provider)
+                    .filter(User.username == username)
+                    .one_or_none()
+                )
+                if not user:
+                    logger.warning(
+                        f"could not find user '{username}' "
+                        f"with identity from provider '{provider}'"
+                    )
+                else:
+                    user.role = role
+
+        db.commit()
 
 
 def _fill_test_database(db: Session) -> NoReturn:
@@ -407,9 +429,9 @@ def create(
     with working_directory(path):
         db = get_session(config.sqlalchemy_database_url)
         _run_migrations(config.sqlalchemy_database_url)
-        _init_db(db, config)
         if dev:
             _fill_test_database(db)
+        _init_db(db, config)
 
 
 def _get_config(path: Union[Path, str]) -> Config:

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -176,7 +176,7 @@ def _init_db(db: Session, config: Config):
                     # use github as default provider
                     raise ValueError(
                         "could not parse the users setting, please provide users in"
-                        "the format 'PROVIDER:USERNAME' where provider is one of"
+                        "the format 'PROVIDER:USERNAME' where PROVIDER is one of"
                         "'google', 'github', 'dummy', etc."
                     )
                 logger.info(f"create user {username} with role {role}")

--- a/quetz/dao_github.py
+++ b/quetz/dao_github.py
@@ -1,6 +1,7 @@
 # Copyright 2020 QuantStack
 # Distributed under the terms of the Modified BSD License.
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from . import rest_models
@@ -8,6 +9,7 @@ from .authorization import OWNER
 from .config import Config
 from .dao import Dao
 from .db_models import Channel, Identity, User
+from .errors import ValidationError
 
 
 def create_user_with_github_identity(
@@ -22,7 +24,7 @@ def create_user_with_github_identity(
         name=github_profile["name"],
         avatar_url=github_profile["avatar_url"],
         role=default_role,
-        exist_ok=True,
+        exist_ok=False,
     )
 
     if create_default_channel:
@@ -75,12 +77,9 @@ def get_user_by_github_identity(dao: Dao, profile: dict, config: Config) -> User
     db = dao.db
 
     try:
-        user, identity = db.query(User, Identity).outerjoin(
-            Identity,
-            User.identities.expression
-            & (Identity.provider == 'github')
-            & (Identity.identity_id == str(profile['id'])),
-        ).one_or_none() or (
+        user, identity = db.query(User, Identity).join(Identity).filter(
+            Identity.provider == 'github'
+        ).filter(Identity.identity_id == str(profile['id']),).one_or_none() or (
             None,
             None,
         )
@@ -94,11 +93,16 @@ def get_user_by_github_identity(dao: Dao, profile: dict, config: Config) -> User
         default_role = None
         create_default_channel = False
 
-    if user and identity:
-        if not identity and user_github_profile_changed(user, identity, profile):
+    if user:
+        if user_github_profile_changed(user, identity, profile):
             return update_user_from_github_profile(db, user, identity, profile)
         return user
 
-    return create_user_with_github_identity(
-        dao, profile, default_role, create_default_channel
-    )
+    try:
+        user = create_user_with_github_identity(
+            dao, profile, default_role, create_default_channel
+        )
+    except IntegrityError:
+        raise ValidationError(f"user name '{profile['login']}' already exists")
+
+    return user


### PR DESCRIPTION
### Breaking changes

*  provider has to be specified with each user in config `[users]` section, for example:

```
[users]
owner = ["github:username"]
```

* to assign roles defined in the config, you will need to re-run `quetz init-db` **after** the user has associated their account with quetz

* only a single identity is allowed to be associated with a username, more identities can be associated with the same user by changing directly data in the db, but due to security concerns this is not exposed with the api

closes #292