### PR TITLE
Add PAM authenticator

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,3 +36,4 @@ dependencies:
   - pyyaml
   - ujson
   - prometheus_client
+  - pamela

--- a/plugins/quetz_dictauthenticator/quetz_dictauthenticator/__init__.py
+++ b/plugins/quetz_dictauthenticator/quetz_dictauthenticator/__init__.py
@@ -28,6 +28,10 @@ class DictionaryAuthenticator(SimpleAuthenticator):
         else:
             self.passwords = {}
 
+        # call the config of base class to configure default roles and
+        # channels
+        super().configure(config)
+
     async def authenticate(self, request, data, **kwargs):
         if self.passwords.get(data['username']) == data['password']:
             return data['username']

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -16,6 +16,7 @@ from . import base
 
 def create_user_with_identity(
     dao: Dao,
+    provider: str,
     profile: 'base.UserProfile',
     default_role: str,
     create_default_channel: bool,
@@ -24,7 +25,7 @@ def create_user_with_identity(
     username = profile["login"]
     user = dao.create_user_with_profile(
         username=username,
-        provider=profile['provider'],
+        provider=provider,
         identity_id=profile["id"],
         name=profile["name"],
         avatar_url=profile["avatar_url"],
@@ -79,10 +80,11 @@ def update_user_from_profile(
     return user
 
 
-def get_user_by_identity(dao: Dao, profile: 'base.UserProfile', config: Config) -> User:
+def get_user_by_identity(
+    dao: Dao, provider: str, profile: 'base.UserProfile', config: Config
+) -> User:
 
     db = dao.db
-    provider = profile.get("provider", "github")
 
     try:
         user, identity = db.query(User, Identity).join(Identity).filter(
@@ -108,7 +110,7 @@ def get_user_by_identity(dao: Dao, profile: 'base.UserProfile', config: Config) 
 
     try:
         user = create_user_with_identity(
-            dao, profile, default_role, create_default_channel
+            dao, provider, profile, default_role, create_default_channel
         )
     except IntegrityError:
         raise ValidationError(f"user name '{profile['login']}' already exists")

--- a/quetz/authentication/base.py
+++ b/quetz/authentication/base.py
@@ -110,7 +110,9 @@ class BaseAuthenticationHandlers:
 
         profile: UserProfile = user_data.get("profile", default_profile)
 
-        user = auth_dao.get_user_by_identity(dao, profile, config)
+        user = auth_dao.get_user_by_identity(
+            dao, self.authenticator.provider, profile, config
+        )
 
         user_id = str(uuid.UUID(bytes=user.id))
 
@@ -194,7 +196,7 @@ class FormHandlers(BaseAuthenticationHandlers):
     <input name="username" autocomplete="name">
   </label>
   <label>password:
-    <input name="password" autocomplete="name">
+    <input name="password" type="password">
   </label>
   <button>Submit</button>
 </form>

--- a/quetz/authentication/github.py
+++ b/quetz/authentication/github.py
@@ -29,3 +29,6 @@ class GithubAuthenticator(OAuthAuthenticator):
             self.is_enabled = True
         else:
             self.is_enabled = False
+
+        # call the configure of base class to set default_channel and default role
+        super().configure(config)

--- a/quetz/authentication/google.py
+++ b/quetz/authentication/google.py
@@ -35,3 +35,6 @@ class GoogleAuthenticator(OAuthAuthenticator):
             self.is_enabled = True
         else:
             self.is_enabled = False
+
+        # call the configure of base class to set default_channel and default role
+        super().configure(config)

--- a/quetz/authentication/oauth2.py
+++ b/quetz/authentication/oauth2.py
@@ -72,7 +72,6 @@ class OAuthAuthenticator(BaseAuthenticator):
     async def authenticate(self, request, data=None, dao=None, config=None):
         token = await self.client.authorize_access_token(request)
         profile = await self.userinfo(request, token)
-        profile['provider'] = self.provider
 
         username = profile["login"]
         auth_state = {"token": json.dumps(token), "provider": self.provider}

--- a/quetz/authentication/pam.py
+++ b/quetz/authentication/pam.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Optional
+
+import pamela
+from fastapi import Request
+
+from quetz.authentication.base import SimpleAuthenticator
+
+logger = logging.getLogger("quetz")
+
+
+class PAMAuthenticator(SimpleAuthenticator):
+
+    provider: str = 'pam'
+
+    service: str = "login"
+    encoding: str = 'utf8'
+    check_account: bool = True
+
+    def configure(self, config):
+        self.is_enabled = True
+
+    async def authenticate(
+        self,
+        request: Request,
+        data: Optional[dict] = None,
+        dao=None,
+        config=None,
+        **kwargs
+    ) -> Optional[str]:
+        """Authenticate with PAM, and return the username if login is successful.
+        Return None otherwise.
+        """
+        if data is None:
+            return None
+
+        username = data['username']
+        try:
+            pamela.authenticate(
+                username, data['password'], service=self.service, encoding=self.encoding
+            )
+        except pamela.PAMError as e:
+            logger.warning(
+                "PAM Authentication failed (%s@%s): %s",
+                username,
+                request.client.host,
+                e,
+            )
+            return None
+
+        if self.check_account:
+            try:
+                pamela.check_account(
+                    username, service=self.service, encoding=self.encoding
+                )
+            except pamela.PAMError as e:
+                logger.warning(
+                    "PAM Account Check failed (%s@%s): %s",
+                    username,
+                    request.client.host,
+                    e,
+                )
+                return None
+
+        return username

--- a/quetz/authentication/pam.py
+++ b/quetz/authentication/pam.py
@@ -1,10 +1,15 @@
+import grp
 import logging
-from typing import Optional
+import os
+import pwd
+from typing import List, Optional
 
 import pamela
 from fastapi import Request
 
-from quetz.authentication.base import SimpleAuthenticator
+from quetz.authentication.base import SimpleAuthenticator, UserProfile
+from quetz.authorization import ServerRole
+from quetz.config import Config, ConfigEntry, ConfigSection
 
 logger = logging.getLogger("quetz")
 
@@ -17,8 +22,79 @@ class PAMAuthenticator(SimpleAuthenticator):
     encoding: str = 'utf8'
     check_account: bool = True
 
-    def configure(self, config):
-        self.is_enabled = True
+    # configure server roles
+    admin_groups: List[str] = []
+    maintainer_groups: List[str] = []
+    member_groups: List[str] = []
+
+    def _make_config(self):
+        section = ConfigSection(
+            "pamauthenticator",
+            [
+                ConfigEntry("provider", str, default="pam", required=False),
+                ConfigEntry("service", str, default="login", required=False),
+                ConfigEntry("encoding", str, default="utf8", required=False),
+                ConfigEntry("check_account", bool, default=True, required=False),
+                ConfigEntry("admin_groups", list, default=list, required=False),
+                ConfigEntry("maintainer_groups", list, default=list, required=False),
+                ConfigEntry("member_groups", list, default=list, required=False),
+            ],
+        )
+        return [section]
+
+    def _get_group_id_by_name(self, groupname):
+        return grp.getgrnam(groupname).gr_gid
+
+    def _get_user_gid_by_name(self, username):
+        return pwd.getpwnam(username).pw_gid
+
+    def _get_group_ids(self, group_names):
+        gids = []
+        for group in group_names:
+            try:
+                gids.append(self._get_group_id_by_name(group))
+            except Exception as exc:
+                logger.warning(f"got error {exc}.  Group {group} may not exist")
+        return gids
+
+    def _get_user_group_ids(self, username):
+        user_gid = self._get_user_gid_by_name(username)
+        return [os.getgrouplist(username, user_gid)]
+
+    def configure(self, config: Config):
+
+        config_options = self._make_config()
+        config.register(config_options)
+
+        if config.configured_section("pamauthenticator"):
+            self.provider = config.pamauthenticator_provider
+            self.service = config.pamauthenticator_service
+            self.encoding = config.pamauthenticator_encoding
+            self.check_account = config.pamauthenticator_check_account
+            self.admin_groups = config.pamauthenticator_admin_groups
+            self.maintainer_groups = config.pamauthenticator_maintainer_groups
+            self.member_groups = config.pamauthenticator_member_groups
+            self.is_enabled = True
+        else:
+            self.is_enabled = False
+
+        super().configure(config)
+
+    def user_role(self, request: Request, profile: UserProfile):
+
+        mappings = [
+            (ServerRole.OWNER, self.admin_groups),
+            (ServerRole.MAINTAINER, self.maintainer_groups),
+            (ServerRole.MEMBER, self.member_groups),
+        ]
+        username = profile["login"]
+
+        user_gids = self._get_user_group_ids(username)
+
+        for role, groups in mappings:
+            role_gids = self._get_group_ids(groups)
+            if set(role_gids) & set(user_gids):
+                return role.value
 
     async def authenticate(
         self,
@@ -26,7 +102,7 @@ class PAMAuthenticator(SimpleAuthenticator):
         data: Optional[dict] = None,
         dao=None,
         config=None,
-        **kwargs
+        **kwargs,
     ) -> Optional[str]:
         """Authenticate with PAM, and return the username if login is successful.
         Return None otherwise.

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -1,6 +1,7 @@
 # Copyright 2020 QuantStack
 # Distributed under the terms of the Modified BSD License.
 
+import enum
 import uuid
 from typing import Optional
 
@@ -19,6 +20,13 @@ SERVER_MEMBER = MEMBER
 SERVER_USER = None
 
 ROLES = [OWNER, MAINTAINER, MEMBER]
+
+
+class ServerRole(str, enum.Enum):
+    OWNER = OWNER
+    MAINTAINER = MAINTAINER
+    MEMBER = MEMBER
+    USER = None
 
 
 class Rules:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -55,6 +55,7 @@ from quetz import (
 from quetz.authentication import AuthenticatorRegistry, BaseAuthenticator
 from quetz.authentication import github as auth_github
 from quetz.authentication import google as auth_google
+from quetz.authentication.pam import PAMAuthenticator
 from quetz.config import PAGINATION_LIMIT, Config, configure_logger, get_plugin_manager
 from quetz.dao import Dao
 from quetz.deps import (
@@ -144,6 +145,7 @@ pkgstore_support_url = hasattr(pkgstore, 'url')
 builtin_authenticators: List[Type[BaseAuthenticator]] = [
     auth_github.GithubAuthenticator,
     auth_google.GoogleAuthenticator,
+    PAMAuthenticator,
 ]
 
 plugin_authenticators: List[Type[BaseAuthenticator]] = [

--- a/quetz/tests/authentification/test_auth_dao.py
+++ b/quetz/tests/authentification/test_auth_dao.py
@@ -8,10 +8,10 @@ def test_get_user_by_identity_new_user(dao, config):
         "login": "bartosz",
         "name": "bartosz",
         "avatar_url": "url",
-        "provider": "github",
     }
+    provider = "github"
 
-    user = auth_dao.get_user_by_identity(dao, profile, config)
+    user = auth_dao.get_user_by_identity(dao, provider, profile, config)
 
     assert user.username == 'bartosz'
     assert user.identities[0].provider == 'github'

--- a/quetz/tests/authentification/test_pam.py
+++ b/quetz/tests/authentification/test_pam.py
@@ -1,3 +1,4 @@
+import getpass
 from unittest import mock
 
 import pytest
@@ -68,3 +69,17 @@ def test_user_role(config, expected_role):
         assert role is None
     else:
         assert role == expected_role
+
+
+@pytest.mark.asyncio
+async def test_authenticate(config):
+
+    auth = PAMAuthenticator(config)
+    request = Request(scope={"type": "http"})
+    current_user = getpass.getuser()
+
+    result = await auth.authenticate(
+        request, {"username": current_user, "password": "test"}
+    )
+
+    assert result is None  # authentication failed due to incorrect password

--- a/quetz/tests/authentification/test_pam.py
+++ b/quetz/tests/authentification/test_pam.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+import pytest
+from fastapi import Request
+
+from quetz.authentication.pam import PAMAuthenticator
+
+
+@pytest.fixture
+def groups():
+    return {}
+
+
+@pytest.fixture
+def config_extra(groups):
+    return f"""
+[pamauthenticator]
+admin_groups = {groups.get('admins', [])}
+maintainer_groups = {groups.get('maintainers', [])}
+member_groups = {groups.get('members', [])}"""
+
+
+@pytest.mark.parametrize(
+    "groups,expected_role",
+    [
+        (
+            {},
+            None,
+        ),
+        (
+            {"admins": ["usergroup"]},
+            "owner",
+        ),
+        (
+            {"admins": ["usergroup"], "maintainers": ["usergroup"]},
+            "owner",
+        ),
+        (
+            {"maintainers": ["usergroup"]},
+            "maintainer",
+        ),
+        (
+            {"members": ["usergroup"]},
+            "member",
+        ),
+        pytest.param(
+            {"members": ["missinggroup"]},
+            None,
+            id="missing-group",
+        ),
+    ],
+)
+def test_user_role(config, expected_role):
+    auth = PAMAuthenticator(config)
+    request = Request(scope={"type": "http"})
+
+    _group_ids = {"usergroup": 1001}
+    _user_group_ids = {"quetzuser": [1001, 1002]}
+
+    with mock.patch.multiple(
+        auth,
+        _get_group_id_by_name=lambda k: _group_ids[k],
+        _get_user_group_ids=lambda k: _user_group_ids[k],
+    ):
+        role = auth.user_role(request, {"login": "quetzuser"})
+
+    if expected_role is None:
+        assert role is None
+    else:
+        assert role == expected_role


### PR DESCRIPTION
note that PAM requires root-permissions (or setuid-root) to check the password for users different than the current one. This is due to the fact that PAM needs an access to read-protected /etc/shadow file that contains users' password hashes.

From pam_unix man page:

> A helper binary, unix_chkpwd(8), is provided to check the user's password when it is stored in a read protected database. This binary is very simple and will only check the password of the user invoking it. It is called transparently on behalf of the user by the authenticating component of this module. In this way it is possible for applications like xlock(1) to work without being setuid-root. The module, by default, will temporarily turn off SIGCHLD handling for the duration of execution of the helper binary. This is generally the right thing to do, as many applications are not prepared to handle this signal from a child they didn't know was fork()d. The noreap module argument can be used to suppress this temporary shielding and may be needed for use with certain applications. 