### PR TITLE
fix memory leak in actions

### DIFF
--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -70,7 +70,10 @@ def job_wrapper(
 
     kwargs.update(extra_kwargs)
 
-    callable_f(**kwargs)
+    try:
+        callable_f(**kwargs)
+    finally:
+        db.close()
 
 
 class AbstractWorker:

--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import time
 from abc import abstractmethod
-from typing import Callable, Optional, Union
+from typing import Callable, Union
 
 import requests
 from fastapi import BackgroundTasks
@@ -159,9 +159,6 @@ class FutureJob(AbstractJob):
 
 
 class SubprocessWorker(AbstractWorker):
-
-    _executor: Optional[concurrent.futures.Executor] = None
-
     def __init__(
         self,
         api_key: str,
@@ -170,11 +167,8 @@ class SubprocessWorker(AbstractWorker):
         executor_args: dict = {},
     ):
 
-        if SubprocessWorker._executor is None:
-            logger.debug("creating a new subprocess executor")
-            SubprocessWorker._executor = concurrent.futures.ProcessPoolExecutor(
-                **executor_args
-            )
+        logger.debug("creating a new subprocess executor")
+        self._executor = concurrent.futures.ProcessPoolExecutor(**executor_args)
         self.api_key = api_key
         self.browser_session = browser_session
         self.config = config


### PR DESCRIPTION
**Update**: the problem with the solution here, is that we can launch unlimited number of workers, which would deplete server's resources. it would be best to have a queue and a fixed number workers that can spawn subprocesses, wait until they are done and tear them down after the job is finished. Similar to what is implemented in rq. Or we could switch completely to rq (BTW quetz rq adapters are not supported with the jobs framework).

related to #332 

## methodology

* trigger generate_indexes action
* watch memory consumption with htop
* try running with and without plugins (both are leaking)
* use tracemalloc
* modify code to return early from the action function
* test with synchronous actions (wait for results, better but still leaking)

## conclusions

there are a couple of memory-related issues:

- workers stay alive after task execution and keep allocated memory (modules etc.)
- python interpreter may dispose of allocated memory as it wishes (for example, keep memory may not release memory recuperated from garbage-collected objects),
- database session is not released after task is done
- other resources may not be released (notably file descriptors, and http connections)
- we don't await results of the execution (not sure if this plays any major role, but the result have to be kept in memory)
- likely memory leaks or implicit caches in some libraries (json and jinja are candidates)
- even without memory leaks, actions such as generating indexes and synchronising mirrors can take huge amount of memory (>2GB), which should be managed more conservatively (for example, run some operations "on disk")

## Fix

this pr works around some of the issues by recreating process executor for each new actions. This may be suboptimal in terms of performance, but it's more conservative with respect to resource management (memory).

we should make it more flexible:

- executor should be kept around for executing multiple related tasks (such as tasks for job framework which is done one per package version)
- we should set number of workers depending on the use case (for jobs, n should be > 1, for actions most likely n=1)