### PR TITLE
retry removing S3 channels on error

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -277,7 +277,6 @@ class S3Store(PackageStore):
         channel_bucket = self._bucket_map(channel)
 
         with self._get_fs() as fs:
-            fs.dircache.clear()
             return [remove_prefix(f, channel_bucket) for f in fs.find(channel_bucket)]
 
     def url(self, channel: str, src: str, expires=3600):

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -14,6 +14,7 @@ from os import PathLike
 from typing import IO, BinaryIO, List, NoReturn, Tuple, Union
 
 import fsspec
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 try:
     import xattr
@@ -222,6 +223,8 @@ class S3Store(PackageStore):
             except FileExistsError:
                 pass
 
+    # we need to retry due to eventual (vs strong) consistency on Openstack Swift
+    @retry(stop=stop_after_attempt(5), retry=retry_if_exception_type(OSError))
     def remove_channel(self, name):
         channel_path = self._bucket_map(name)
         self.fs.rm(channel_path, recursive=True, acl="private")

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -143,20 +143,28 @@ def channel(any_store, channel_name):
 
 
 def test_store_add_list_files(any_store, channel, channel_name):
+    def assert_files(expected_files, n_retries=3):
+        n_retries = 3
+
+        for i in range(n_retries):
+            try:
+                files = pkg_store.list_files(channel_name)
+                assert files == expected_files
+            except AssertionError:
+                continue
+            break
+        assert files == expected_files
 
     pkg_store = any_store
 
     pkg_store.add_file("content", channel_name, "test.txt")
     pkg_store.add_file("content", channel_name, "test_2.txt")
 
-    files = pkg_store.list_files(channel_name)
-
-    assert files == ["test.txt", "test_2.txt"]
+    assert_files(["test.txt", "test_2.txt"])
 
     pkg_store.delete_file(channel_name, "test.txt")
 
-    files = pkg_store.list_files(channel_name)
-    assert files == ["test_2.txt"]
+    assert_files(["test_2.txt"])
 
     metadata = pkg_store.get_filemetadata(channel_name, "test_2.txt")
     assert metadata[0] > 0


### PR DESCRIPTION
since deletions/additions may not be immediately visible on s3, we need to retry sometimes.

AWS S3 has strong consistency since recently: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/

OpenStack Swift (the backend behind OVH S3) has eventual consistency:

https://julien.danjou.info/openstack-swift-consistency-analysis/