### PR TITLE
fork worker for executing task

### DIFF
--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -52,7 +52,7 @@ def job_wrapper(
         child_pid = os.fork()
 
         if child_pid > 0:
-            pid, stat = os.waitpid(child_pid)
+            pid, stat = os.waitpid(child_pid, 0)
             return
 
     # database connections etc. are not serializable
@@ -210,7 +210,7 @@ class SubprocessWorker(AbstractWorker):
         if self._executor is None:
             logger.debug("creating a new subprocess executor")
             SubprocessWorker._executor = concurrent.futures.ProcessPoolExecutor(
-                max_workers=1, **executor_args
+                max_workers=2, **executor_args
             )
 
         self.api_key = api_key

--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -243,10 +243,13 @@ class SubprocessWorker(AbstractWorker):
         executor_args: dict = {},
     ):
 
+        if 'max_workers' not in executor_args:
+            executor_args['max_workers'] = 2
+
         if self._executor is None:
             logger.debug("creating a new subprocess executor")
             SubprocessWorker._executor = concurrent.futures.ProcessPoolExecutor(
-                max_workers=2, **executor_args
+                **executor_args
             )
 
         self.api_key = api_key


### PR DESCRIPTION
inspired by rq's worker implementation: https://github.com/rq/rq/blob/fc7940c77b69704ad6c059385fd530c850e5f0be/rq/worker.py#L741

SubprocessWorker has following deficiencies:

- unlimited number or workers can be launched in parallel and so there is no way to manage the server ressources
- actions are fire-and-forget so we (users and admins) never learn about possible exceptions during the executions, maybe logging them would be a step forward

This PR addresses the first one.