### PR TITLE
remove check_status from job watch

### DIFF
--- a/quetz/tests/api/conftest.py
+++ b/quetz/tests/api/conftest.py
@@ -84,6 +84,8 @@ def make_package_version(
 
     pkgstore = config.get_package_store()
 
+    versions = []
+
     def _make_package_version(filename, version_number, platform="linux-64"):
         filename = Path(filename)
         with open(filename, "rb") as fid:
@@ -106,19 +108,22 @@ def make_package_version(
 
         dao.update_channel_size(channel_name)
 
+        versions.append(version)
+
         return version
 
     yield _make_package_version
+
+    for version in versions:
+        db.delete(version)
+    db.commit()
 
 
 @pytest.fixture
 def package_version(db, make_package_version):
     version = make_package_version("test-package-0.1-0.tar.bz2", "0.1")
 
-    yield version
-
-    db.delete(version)
-    db.commit()
+    return version
 
 
 @pytest.fixture()

--- a/quetz/tests/api/test_channels.py
+++ b/quetz/tests/api/test_channels.py
@@ -185,7 +185,15 @@ def test_get_channel_members(auth_client, public_channel, expected_code):
     assert response.status_code == expected_code
 
 
-def test_channel_names_are_case_insensitive(auth_client, maintainer):
+@pytest.fixture
+def remove_package_versions(db):
+    yield
+    db.query(db_models.PackageVersion).delete()
+
+
+def test_channel_names_are_case_insensitive(
+    auth_client, maintainer, remove_package_versions
+):
 
     channel_name = "MyChanneL"
 
@@ -333,7 +341,12 @@ def test_accents_make_unique_channel_names(auth_client, maintainer):
 
 
 def test_upload_package_version_to_channel(
-    auth_client, public_channel, maintainer, db, config
+    auth_client,
+    public_channel,
+    maintainer,
+    db,
+    config,
+    remove_package_versions,
 ):
     pkgstore = config.get_package_store()
 

--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -227,9 +227,21 @@ def test_get_non_existing_package_version(
     assert response.status_code == 404
 
 
+@pytest.fixture
+def remove_package_versions(db):
+    yield
+    db.query(PackageVersion).delete()
+
+
 @pytest.mark.parametrize("package_name", ["test-package", "my-package"])
 def test_upload_package_version(
-    auth_client, public_channel, public_package, package_name, db, config
+    auth_client,
+    public_channel,
+    public_package,
+    package_name,
+    db,
+    config,
+    remove_package_versions,
 ):
     pkgstore = config.get_package_store()
 
@@ -332,7 +344,7 @@ def test_package_name_length_limit(auth_client, public_channel, db):
     assert pkg is not None
 
 
-def test_validate_package_names(auth_client, public_channel):
+def test_validate_package_names(auth_client, public_channel, remove_package_versions):
 
     valid_package_names = [
         "interesting-package",
@@ -374,7 +386,13 @@ def test_validate_package_names(auth_client, public_channel):
     ],
 )
 def test_validate_package_names_files_endpoint(
-    auth_client, public_channel, mocker, package_name, msg, config: Config
+    auth_client,
+    public_channel,
+    mocker,
+    package_name,
+    msg,
+    config: Config,
+    remove_package_versions,
 ):
 
     pkgstore = config.get_package_store()
@@ -508,7 +526,10 @@ def test_get_package_with_versions(
 
 @pytest.mark.parametrize("package_name", ["test-package"])
 def test_package_channel_data_attributes(
-    auth_client, make_package_version, channel_name
+    auth_client,
+    make_package_version,
+    channel_name,
+    remove_package_versions,
 ):
     # test attributes derived from channel data
     for package_filename in Path(".").glob("*.tar.bz2"):

--- a/quetz/tests/api/test_metrics.py
+++ b/quetz/tests/api/test_metrics.py
@@ -132,11 +132,13 @@ def test_get_download_count(auth_client, public_channel, package_version, db, da
 
 
 @pytest.fixture
-def package_version_factory(channel_name, user, dao, public_package):
+def package_version_factory(channel_name, user, dao, public_package, db):
 
     package_format = "tarbz2"
     package_info = "{}"
     package_name = public_package.name
+
+    versions = []
 
     def factory(version, build_str=0, platform="linux-64"):
 
@@ -155,9 +157,14 @@ def package_version_factory(channel_name, user, dao, public_package):
             user.id,
             size=11,
         )
+        versions.append(version)
         return version
 
-    return factory
+    yield factory
+
+    for version in versions:
+        db.delete(version)
+    db.commit()
 
 
 def test_get_channel_download_count(

--- a/quetz/tests/conftest.py
+++ b/quetz/tests/conftest.py
@@ -32,6 +32,9 @@ def user_without_profile(db, user_role):
 
     yield new_user
 
+    db.delete(new_user)
+    db.commit()
+
 
 @fixture
 def user(db, user_without_profile):

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -161,7 +161,7 @@ def failed_func(package_version: dict):
 
 
 def long_running(package_version: dict):
-    time.sleep(0.1)
+    time.sleep(0.25)
 
 
 def dummy_func(package_version: dict):
@@ -265,10 +265,14 @@ async def test_running_task(db, user, package_version, manager):
 
     assert task.status == TaskStatus.pending
 
-    time.sleep(0.05)
-    check_status(db)
+    # wait for task status to change
+    for i in range(10):
+        time.sleep(0.05)
 
-    db.refresh(task)
+        db.refresh(task)
+        if task.status != TaskStatus.pending:
+            break
+
     assert task.status == TaskStatus.running
 
     # wait for job to finish
@@ -686,10 +690,11 @@ def test_validate_query_string(auth_client, query_str, ok):
         assert response.status_code == 422
 
 
-@pytest.mark.parametrize("user_role", ["owner"])
-@pytest.mark.parametrize("skip,limit", [(0, 2), (1, -1), (2, 1), (2, 5)])
-def test_jobs_pagination(auth_client, db, user, skip, limit):
+@pytest.fixture
+def many_jobs(db, user):
+
     n_jobs = 5
+    jobs = []
     for i in range(n_jobs):
         job = Job(
             id=i,
@@ -699,6 +704,20 @@ def test_jobs_pagination(auth_client, db, user, skip, limit):
             owner=user,
         )
         db.add(job)
+        jobs.append(job)
+
+    yield jobs
+
+    for job in jobs:
+        db.delete(job)
+    db.commit()
+
+
+@pytest.mark.parametrize("user_role", ["owner"])
+@pytest.mark.parametrize("skip,limit", [(0, 2), (1, -1), (2, 1), (2, 5)])
+def test_jobs_pagination(auth_client, skip, limit, many_jobs):
+
+    n_jobs = len(many_jobs)
 
     response = auth_client.get(f"/api/jobs?skip={skip}&limit={limit}")
     assert response.status_code == 200

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -38,6 +38,14 @@ def proxy_channel(db):
     db.commit()
 
 
+@pytest.fixture(autouse=True)
+def remove_package_versions(db, user):
+    # we need to run this fixture before use, hence the dependency
+    # on user fixture
+    yield
+    db.query(PackageVersion).delete()
+
+
 @pytest.fixture
 def mirror_channel(dao, user, db):
 

--- a/quetz/tests/test_tasks.py
+++ b/quetz/tests/test_tasks.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from quetz.db_models import PackageVersion
 from quetz.pkgstores import PackageStore
 from quetz.rest_models import Channel
 from quetz.tasks.indexing import validate_packages
@@ -42,6 +43,16 @@ def channel(dao, user, channel_name):
     return channel
 
 
+@pytest.fixture
+def remove_package_versions(db):
+    # clean up the created package versions after the test
+
+    yield
+
+    db.query(PackageVersion).delete()
+    db.commit()
+
+
 def test_reindex_package_files(
     config,
     user,
@@ -51,6 +62,7 @@ def test_reindex_package_files(
     dao,
     pkgstore: PackageStore,
     package_filenames,
+    remove_package_versions,
 ):
     user_id = user.id
     reindex_packages_from_store(dao, config, channel.name, user_id)


### PR DESCRIPTION
since #364 check_status is no longer required - workers update themselves the task/job status