### PR TITLE
Refactor supervisor

### DIFF
--- a/plugins/quetz_harvester/tests/conftest.py
+++ b/plugins/quetz_harvester/tests/conftest.py
@@ -7,6 +7,7 @@ from quetz.authorization import SERVER_OWNER
 from quetz.config import Config
 from quetz.dao import Dao
 from quetz.db_models import Profile, User
+from quetz.jobs.runner import Supervisor
 from quetz.rest_models import Channel, Package
 from quetz.tasks.workers import SubprocessWorker
 
@@ -48,9 +49,10 @@ def auth_client(client, user):
 
 
 @pytest.fixture
-def work_manager(config):
+def supervisor(config, db):
     manager = SubprocessWorker("", {}, config)
-    return manager
+    supervisor = Supervisor(db, manager)
+    return supervisor
 
 
 @pytest.fixture

--- a/plugins/quetz_harvester/tests/conftest.py
+++ b/plugins/quetz_harvester/tests/conftest.py
@@ -50,7 +50,7 @@ def auth_client(client, user):
 
 @pytest.fixture
 def supervisor(config, db):
-    manager = SubprocessWorker("", {}, config)
+    manager = SubprocessWorker(config)
     supervisor = Supervisor(db, manager)
     return supervisor
 

--- a/plugins/quetz_harvester/tests/test_main.py
+++ b/plugins/quetz_harvester/tests/test_main.py
@@ -5,23 +5,22 @@ from httpx import AsyncClient
 
 from quetz.db_models import PackageVersion
 from quetz.jobs.models import Job, Task, TaskStatus
-from quetz.jobs.runner import check_status, run_jobs, run_tasks
 
 
 @pytest.mark.asyncio
 async def test_harvest_endpoint_and_job(
-    auth_client, db, config, work_manager, package_version, app, channel_name
+    auth_client, db, config, supervisor, package_version, app, channel_name
 ):
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.put("/api/harvester", json={"package_spec": "*"})
 
     assert response.status_code == 200
-    run_jobs(db)
-    new_jobs = run_tasks(db, work_manager)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
     await new_jobs[0].wait()
 
-    check_status(db)
+    supervisor.check_status()
 
     task = db.query(Task).one()
     db.refresh(task)

--- a/plugins/quetz_transmutation/README.md
+++ b/plugins/quetz_transmutation/README.md
@@ -10,3 +10,14 @@ To install use:
 ```
 pip install .
 ```
+
+## Using
+
+Run the transumtation job on all packages (server wide) using the following RESTful request:
+
+```
+QUETZ_API_KEY=...
+curl -X POST localhost:8000/api/jobs \
+   -H "X-api-key: ${QUETZ_API_KEY}" \
+   -d '{"items_spec": "*", "manifest": "quetz-transmutation:transmutation"}'
+```

--- a/plugins/quetz_transmutation/tests/conftest.py
+++ b/plugins/quetz_transmutation/tests/conftest.py
@@ -66,7 +66,7 @@ def auth_client(client, user):
 
 @pytest.fixture
 def supervisor(config, db):
-    manager = SubprocessWorker("", {}, config)
+    manager = SubprocessWorker(config)
     supervisor = Supervisor(db, manager)
     return supervisor
 

--- a/plugins/quetz_transmutation/tests/conftest.py
+++ b/plugins/quetz_transmutation/tests/conftest.py
@@ -8,6 +8,7 @@ from quetz.authorization import SERVER_OWNER
 from quetz.config import Config
 from quetz.dao import Dao
 from quetz.db_models import ApiKey, Profile, User
+from quetz.jobs.runner import Supervisor
 from quetz.rest_models import Channel, Package
 from quetz.tasks.workers import SubprocessWorker
 
@@ -64,9 +65,10 @@ def auth_client(client, user):
 
 
 @pytest.fixture
-def work_manager(config):
+def supervisor(config, db):
     manager = SubprocessWorker("", {}, config)
-    return manager
+    supervisor = Supervisor(db, manager)
+    return supervisor
 
 
 @pytest.fixture

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -32,7 +32,7 @@ class ServerRole(str, enum.Enum):
 
 
 class Rules:
-    def __init__(self, API_key: str, session: dict, db: Session):
+    def __init__(self, API_key: Optional[str], session: dict, db: Session):
         self.API_key = API_key
         self.session = session
         self.db = db

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -658,7 +658,7 @@ def start_supervisor_daemon(path, num_procs=None):
 
     configure_logger(loggers=("quetz",))
     config = _get_config(path)
-    manager = SubprocessWorker("", {}, config, {'max_workers': num_procs})
+    manager = SubprocessWorker(config, {'max_workers': num_procs})
     with working_directory(path):
         db = get_session(config.sqlalchemy_database_url)
         supervisor = Supervisor(db, manager)

--- a/quetz/deps.py
+++ b/quetz/deps.py
@@ -104,15 +104,13 @@ def get_tasks_worker(
     if worker == "thread":
         worker = ThreadingWorker(background_tasks, dao, auth, session, config)
     elif worker == "subprocess":
-        worker = SubprocessWorker(auth.API_key, auth.session, config)
+        worker = SubprocessWorker(config)
     elif worker == "redis":
         if rq_available:
             worker = RQManager(
                 config.worker_redis_ip,
                 config.worker_redis_port,
                 config.worker_redis_db,
-                auth.API_key,
-                auth.session,
                 config,
             )
         else:

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -18,7 +18,6 @@ from quetz.rest_models import PaginatedResponse
 
 from .models import JobStatus, TaskStatus
 from .rest_models import Job, JobBase, JobUpdateModel, Task
-from .runner import run_jobs
 
 api_router = APIRouter()
 
@@ -98,8 +97,9 @@ def update_job(
     job.status = job_data.status  # type: ignore
 
     # ignore tasks that have already been run
-    if job_data.force:
-        run_jobs(db, job_id=job.id, force=True)
+    # if job_data.force:
+    #    run_jobs(db, job_id=job.id, force=True)
+    # change status to 'created' instead
 
     db.commit()
 

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -96,10 +96,13 @@ def update_job(
     auth.assert_jobs(owner_id=job.owner_id)
     job.status = job_data.status  # type: ignore
 
-    # ignore tasks that have already been run
-    # if job_data.force:
-    #    run_jobs(db, job_id=job.id, force=True)
-    # change status to 'created' instead
+    if job_data.force and job.status in [
+        JobStatus.running,
+        JobStatus.pending,
+    ]:
+        # restart tasks that have already been run
+        for task in job.tasks:
+            task.status = "skipped"
 
     db.commit()
 

--- a/quetz/jobs/models.py
+++ b/quetz/jobs/models.py
@@ -66,7 +66,7 @@ class Job(Base):
         default=JobStatus.pending,
     )
 
-    tasks = sa.orm.relationship('Task', cascade="all,delete-orphan")
+    tasks = sa.orm.relationship('Task', cascade="all,delete-orphan", uselist=True)
 
 
 class Task(Base):

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+import time
 from typing import Dict, List
 
 import sqlalchemy as sa
@@ -12,9 +13,6 @@ from quetz.jobs.models import ItemsSelection, Job, JobStatus, Task, TaskStatus
 
 logger = logging.getLogger('quetz-cli')
 # manager = RQManager("127.0.0.1", 6379, 0, "", {}, config)
-
-
-_process_cache = {}
 
 
 def build_queue(job):
@@ -105,116 +103,142 @@ def build_sql_from_package_spec(selector: str):
     return sql_expr
 
 
-def run_jobs(db, job_id=None, force=False):
-    jobs = db.query(Job).filter(Job.status == JobStatus.pending)
-    if job_id:
-        jobs = jobs.filter(Job.id == job_id)
-    for job in jobs:
-        if job.items == ItemsSelection.all:
-            if force:
-                q = db.query(PackageVersion)
-            else:
-                existing_task = (
-                    db.query(Task.package_version_id, Task.id.label("task_id"))
-                    .filter(Task.job_id == job.id)
-                    .subquery()
-                )
-                q = (
-                    db.query(PackageVersion)
-                    .outerjoin(
-                        existing_task,
-                        PackageVersion.id == existing_task.c.package_version_id,
+class Supervisor:
+    """Watches for new jobs and dispatches tasks."""
+
+    def __init__(self, db, manager):
+        self.db = db
+        self.manager = manager
+        self._process_cache = {}
+        pass
+
+    def run_jobs(self, job_id=None, force=False):
+        db = self.db
+        jobs = db.query(Job).filter(Job.status == JobStatus.pending)
+        if job_id:
+            jobs = jobs.filter(Job.id == job_id)
+        for job in jobs:
+            if job.items == ItemsSelection.all:
+                if force:
+                    q = db.query(PackageVersion)
+                else:
+                    existing_task = (
+                        db.query(Task.package_version_id, Task.id.label("task_id"))
+                        .filter(Task.job_id == job.id)
+                        .subquery()
                     )
-                    .filter(existing_task.c.task_id.is_(None))
-                )
-        else:
-            raise NotImplementedError(f"selection {job.items} is not implemented")
+                    q = (
+                        db.query(PackageVersion)
+                        .outerjoin(
+                            existing_task,
+                            PackageVersion.id == existing_task.c.package_version_id,
+                        )
+                        .filter(existing_task.c.task_id.is_(None))
+                    )
+            else:
+                raise NotImplementedError(f"selection {job.items} is not implemented")
 
-        if job.items_spec:
-            try:
-                filter_expr = build_sql_from_package_spec(job.items_spec)
-            except Exception as e:
-                logger.error(f"got error when parsing package spec: {e}")
-                job.status = JobStatus.failed
-                continue
-            q = q.filter(filter_expr)
-        else:
-            logger.warning("empty package spec returns no results")
-            # it might be also job created in actions
-            # so skipping here
-            continue
-
-        job.status = JobStatus.running
-
-        task = None
-        for version in q:
-            task = Task(job=job, package_version=version)
-            db.add(task)
-        if not task:
-            logger.warning(
-                f"no versions matching the package spec {job.items_spec}. skipping."
-            )
             if job.items_spec:
-                # actions have no related package versions
-                job.status = JobStatus.success
-    db.commit()
+                try:
+                    filter_expr = build_sql_from_package_spec(job.items_spec)
+                except Exception as e:
+                    logger.error(f"got error when parsing package spec: {e}")
+                    job.status = JobStatus.failed
+                    continue
+                q = q.filter(filter_expr)
+            else:
+                # it might be also job created in actions
+                # so skipping here
+                continue
 
+            job.status = JobStatus.running
 
-def add_task_to_queue(db, manager, task, *args, func=None, **kwargs):
-    """add task to the queue"""
+            task = None
+            for version in q:
+                task = Task(job=job, package_version=version)
+                db.add(task)
+            if not task:
+                logger.warning(
+                    f"no versions matching the package spec {job.items_spec}. skipping."
+                )
+                if job.items_spec:
+                    # actions have no related package versions
+                    job.status = JobStatus.success
+        db.commit()
 
-    if func is None:
-        func = task.job.manifest
-    task.status = TaskStatus.pending
-    task.job.status = JobStatus.running
-    db.add(task)
-    db.commit()
-    job = manager.execute(func, *args, task_id=task.id, **kwargs)
-    _process_cache[task.id] = job
-    return job
+    def add_task_to_queue(self, db, manager, task, *args, func=None, **kwargs):
+        """add task to the queue"""
 
+        db = self.db
+        manager = self.manager
+        _process_cache = self._process_cache
 
-def run_tasks(db, manager):
+        if func is None:
+            func = task.job.manifest
+        task.status = TaskStatus.pending
+        task.job.status = JobStatus.running
+        db.add(task)
+        db.commit()
+        job = manager.execute(func, *args, task_id=task.id, **kwargs)
+        _process_cache[task.id] = job
+        return job
 
-    tasks = (
-        db.query(Task)
-        .filter(Task.status == TaskStatus.created)
-        .filter(Task.package_version_id.isnot(None))
-    )
-    task: Task
-    logger.info(f"Got pending tasks: {tasks.count()}")
-    jobs = []
-    for task in tasks:
-        if not task.package_version:
-            # task was launched from actions
-            continue
-        version_dict = {
-            "filename": task.package_version.filename,
-            "channel_name": task.package_version.channel_name,
-            "package_format": task.package_version.package_format,
-            "platform": task.package_version.platform,
-            "version": task.package_version.version,
-            "build_string": task.package_version.build_string,
-            "build_number": task.package_version.build_number,
-            "size": task.package_version.size,
-            "package_name": task.package_version.package_name,
-            "info": task.package_version.info,
-            "uploader_id": task.package_version.uploader_id,
-        }
-        job = add_task_to_queue(db, manager, task, package_version=version_dict)
-        jobs.append(job)
-    db.commit()
-    return jobs
+    def run_tasks(self):
+        """dispatch tasks"""
 
+        db = self.db
+        manager = self.manager
 
-def check_status(db):
-    tasks = (
-        db.query(Task)
-        .filter(Task.status.in_([TaskStatus.running, TaskStatus.pending]))
-        .filter(Task.package_version_id.isnot(None))
-    )
-    for task in tasks:
-        if task.id not in _process_cache:
-            logger.warning(f"running process for task {task} is lost, restarting")
-            task.status = TaskStatus.created
-    db.commit()
+        tasks = (
+            db.query(Task)
+            .filter(Task.status == TaskStatus.created)
+            .filter(Task.package_version_id.isnot(None))
+        )
+        task: Task
+        logger.info(f"Got pending tasks: {tasks.count()}")
+        jobs = []
+        for task in tasks:
+            if not task.package_version:
+                # task was launched from actions
+                continue
+            version_dict = {
+                "filename": task.package_version.filename,
+                "channel_name": task.package_version.channel_name,
+                "package_format": task.package_version.package_format,
+                "platform": task.package_version.platform,
+                "version": task.package_version.version,
+                "build_string": task.package_version.build_string,
+                "build_number": task.package_version.build_number,
+                "size": task.package_version.size,
+                "package_name": task.package_version.package_name,
+                "info": task.package_version.info,
+                "uploader_id": task.package_version.uploader_id,
+            }
+            job = self.add_task_to_queue(
+                db, manager, task, package_version=version_dict
+            )
+            jobs.append(job)
+        db.commit()
+        return jobs
+
+    def check_status(self):
+
+        tasks = (
+            self.db.query(Task)
+            .filter(Task.status.in_([TaskStatus.running, TaskStatus.pending]))
+            .filter(Task.package_version_id.isnot(None))
+        )
+        for task in tasks:
+            if task.id not in self._process_cache:
+                logger.warning(f"running process for task {task} is lost, restarting")
+                task.status = TaskStatus.created
+        self.db.commit()
+
+    def run(self):
+        """main loop"""
+
+        while True:
+            self.run_jobs()
+            self.run_tasks()
+            self.check_status()
+            time.sleep(5)

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from quetz.db_models import PackageVersion
 from quetz.jobs.models import ItemsSelection, Job, JobStatus, Task, TaskStatus
 
-logger = logging.getLogger('quetz-cli')
+logger = logging.getLogger('quetz.tasks')
 # manager = RQManager("127.0.0.1", 6379, 0, "", {}, config)
 
 

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -125,6 +125,7 @@ class Supervisor:
                     existing_task = (
                         db.query(Task.package_version_id, Task.id.label("task_id"))
                         .filter(Task.job_id == job.id)
+                        .filter(Task.status != TaskStatus.skipped)
                         .subquery()
                     )
                     q = (

--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -6,7 +6,7 @@ import pickle
 import time
 from abc import abstractmethod
 from multiprocessing import get_context
-from typing import Callable, Union
+from typing import Callable, Dict, Union
 
 import requests
 from fastapi import BackgroundTasks
@@ -89,8 +89,6 @@ class WorkerProcess:
 
 def job_wrapper(
     func: Union[Callable, bytes],
-    api_key,
-    browser_session,
     config,
     task_id=None,
     **kwargs,
@@ -114,21 +112,28 @@ def job_wrapper(
     auth = kwargs.pop("auth", None)
     session = kwargs.pop("session", None)
 
-    if not pkgstore:
-        pkgstore = config.get_package_store()
     if not db:
         db = get_session(config.sqlalchemy_database_url)
-    if not dao:
-        dao = Dao(db)
-    if not auth:
-        auth = Rules(api_key, browser_session, db)
-    if not session:
-        session = get_remote_session()
 
     if task_id:
         task = db.query(Task).filter(Task.id == task_id).one_or_none()
     else:
         task = None
+
+    if not pkgstore:
+        pkgstore = config.get_package_store()
+
+    if not dao:
+        dao = Dao(db)
+
+    if not auth:
+        browser_session: Dict[str, str] = {}
+        api_key = None
+        if task:
+            browser_session['user_id'] = task.job.owner_id
+        auth = Rules(api_key, browser_session, db)
+    if not session:
+        session = get_remote_session()
 
     if task:
         task.status = TaskStatus.running
@@ -247,8 +252,6 @@ class ThreadingWorker(AbstractWorker):
         self.background_tasks.add_task(
             job_wrapper,
             func,
-            self.auth.API_key,
-            self.auth.session,
             self.config,
             *args,
             **kwargs,
@@ -292,8 +295,6 @@ class SubprocessWorker(AbstractWorker):
 
     def __init__(
         self,
-        api_key: str,
-        browser_session: dict,
         config: Config,
         executor_args: dict = {},
     ):
@@ -307,15 +308,11 @@ class SubprocessWorker(AbstractWorker):
                 **executor_args
             )
 
-        self.api_key = api_key
-        self.browser_session = browser_session
         self.config = config
         self.future = None
 
     def execute(self, func, *args, **kwargs):
-        process = WorkerProcess(
-            func, self.api_key, self.browser_session, self.config, *args, **kwargs
-        )
+        process = WorkerProcess(func, self.config, *args, **kwargs)
         self.future = self._executor.submit(process)
         return FutureJob(self.future)
 
@@ -331,16 +328,12 @@ class RQManager(AbstractWorker):
         host,
         port,
         db,
-        api_key: str,
-        browser_session: dict,
         config: Config,
         no_testing=True,
     ):
         self.host = host
         self.port = port
         self.db = db
-        self.api_key = api_key
-        self.browser_session = browser_session
         self.config = config
         self.conn = redis.StrictRedis(host=self.host, port=self.port, db=self.db)
         self.queue = Queue(connection=self.conn, is_async=no_testing)
@@ -349,8 +342,6 @@ class RQManager(AbstractWorker):
         self.job = self.queue.enqueue(
             job_wrapper,
             func,
-            self.api_key,
-            self.browser_session,
             self.config,
             *args,
             **kwargs,

--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import pickle
 import time
+import uuid
 from abc import abstractmethod
 from multiprocessing import get_context
 from typing import Callable, Dict, Union
@@ -129,8 +130,9 @@ def job_wrapper(
     if not auth:
         browser_session: Dict[str, str] = {}
         api_key = None
-        if task:
-            browser_session['user_id'] = task.job.owner_id
+        if task and task.job.owner_id:
+            user_id = str(uuid.UUID(bytes=task.job.owner_id))
+            browser_session['user_id'] = user_id
         auth = Rules(api_key, browser_session, db)
     if not session:
         session = get_remote_session()

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -133,7 +133,7 @@ def public_package(db, user, public_channel, dao, package_role, package_name):
 @pytest.fixture
 def manager(config, db):
 
-    manager = SubprocessWorker("", {}, config)
+    manager = SubprocessWorker(config)
     yield manager
     manager._executor.shutdown()
     SubprocessWorker._executor = None

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -12,14 +12,7 @@ from quetz.config import Config
 from quetz.dao import Dao
 from quetz.db_models import User
 from quetz.jobs.models import Job, JobStatus, Task, TaskStatus
-from quetz.jobs.runner import (
-    _process_cache,
-    check_status,
-    mk_sql_expr,
-    parse_conda_spec,
-    run_jobs,
-    run_tasks,
-)
+from quetz.jobs.runner import Supervisor, mk_sql_expr, parse_conda_spec
 from quetz.rest_models import Channel, Package
 from quetz.tasks.workers import SubprocessWorker
 
@@ -148,6 +141,12 @@ def manager(config, db):
     db.commit()
 
 
+@pytest.fixture
+def supervisor(db, config, manager):
+    supervisor = Supervisor(db, manager)
+    return supervisor
+
+
 def test_create_task(db, user, package_version):
     job = Job(owner_id=user.id, manifest=b"")
     task = Task(job=job)
@@ -174,14 +173,14 @@ def dummy_func(package_version: dict):
 
 
 @pytest.mark.asyncio
-async def test_create_job(db, user, package_version, manager):
+async def test_create_job(db, user, package_version, supervisor):
 
     func_serialized = pickle.dumps(func)
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec="*")
     db.add(job)
     db.commit()
-    run_jobs(db)
-    new_jobs = run_tasks(db, manager)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
     db.refresh(job)
     task = db.query(Task).one()
 
@@ -192,7 +191,7 @@ async def test_create_job(db, user, package_version, manager):
     # wait for job to finish
     await new_jobs[0].wait()
 
-    check_status(db)
+    supervisor.check_status()
 
     db.refresh(task)
     assert task.status == TaskStatus.success
@@ -204,20 +203,20 @@ async def test_create_job(db, user, package_version, manager):
 
 @pytest.mark.asyncio
 async def test_run_tasks_only_on_new_versions(
-    db, user, package_version, manager, dao, channel_name, package_name
+    db, user, package_version, dao, channel_name, package_name, supervisor
 ):
 
     func_serialized = pickle.dumps(dummy_func)
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec="*")
     db.add(job)
     db.commit()
-    run_jobs(db)
-    new_jobs = run_tasks(db, manager)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
     db.refresh(job)
     task = db.query(Task).one()
 
     await new_jobs[0].wait()
-    check_status(db)
+    supervisor.check_status()
     db.refresh(task)
     db.refresh(job)
     assert task.status == TaskStatus.success
@@ -225,9 +224,9 @@ async def test_run_tasks_only_on_new_versions(
 
     job.status = JobStatus.pending
     db.commit()
-    run_jobs(db)
-    new_jobs = run_tasks(db, manager)
-    check_status(db)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
+    supervisor.check_status()
     db.refresh(job)
     assert not new_jobs
     assert job.status == JobStatus.success
@@ -237,8 +236,8 @@ async def test_run_tasks_only_on_new_versions(
 
     job.status = JobStatus.pending
     db.commit()
-    run_jobs(db)
-    new_jobs = run_tasks(db, manager)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
     assert len(new_jobs) == 1
     assert job.status == JobStatus.running
     assert len(job.tasks) == 2
@@ -247,22 +246,22 @@ async def test_run_tasks_only_on_new_versions(
 
     # force rerunning
     job.status = JobStatus.pending
-    run_jobs(db, force=True)
+    supervisor.run_jobs(force=True)
     db.refresh(job)
-    new_jobs = run_tasks(db, manager)
+    new_jobs = supervisor.run_tasks()
     assert len(job.tasks) == 4
     assert len(new_jobs) == 2
 
 
 @pytest.mark.asyncio
-async def test_running_task(db, user, package_version, manager):
+async def test_running_task(db, user, package_version, supervisor):
 
     func_serialized = pickle.dumps(long_running)
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec="*")
     db.add(job)
     db.commit()
-    run_jobs(db)
-    processes = run_tasks(db, manager)
+    supervisor.run_jobs()
+    processes = supervisor.run_tasks()
     db.refresh(job)
     task = db.query(Task).one()
 
@@ -283,22 +282,22 @@ async def test_running_task(db, user, package_version, manager):
     # wait for job to finish
     await processes[0].wait()
 
-    check_status(db)
+    supervisor.check_status()
 
     db.refresh(task)
     assert task.status == TaskStatus.success
 
 
 @pytest.mark.asyncio
-async def test_restart_worker_process(db, user, package_version, manager, caplog):
+async def test_restart_worker_process(db, user, package_version, supervisor, caplog):
     # test if we can resume jobs if a worker was killed/restarted
     func_serialized = pickle.dumps(long_running)
 
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec="*")
     db.add(job)
     db.commit()
-    run_jobs(db)
-    run_tasks(db, manager)
+    supervisor.run_jobs()
+    supervisor.run_tasks()
     db.refresh(job)
     task = db.query(Task).one()
 
@@ -317,22 +316,22 @@ async def test_restart_worker_process(db, user, package_version, manager, caplog
     db.refresh(task)
     assert task.status == TaskStatus.running
 
-    _process_cache.clear()
+    supervisor._process_cache.clear()
 
-    check_status(db)
+    supervisor.check_status()
     assert task.status == TaskStatus.created
     assert "lost" in caplog.text
 
-    new_processes = run_tasks(db, manager)
+    new_processes = supervisor.run_tasks()
     db.refresh(task)
 
     assert len(new_processes) == 1
     assert task.status == TaskStatus.pending
 
-    more_processes = run_tasks(db, manager)
+    more_processes = supervisor.run_tasks()
     await new_processes[0].wait()
-    even_more_processes = run_tasks(db, manager)
-    check_status(db)
+    even_more_processes = supervisor.run_tasks()
+    supervisor.check_status()
     db.refresh(task)
     assert not more_processes
     assert not even_more_processes
@@ -340,19 +339,19 @@ async def test_restart_worker_process(db, user, package_version, manager, caplog
 
 
 @pytest.mark.asyncio
-async def test_failed_task(db, user, package_version, manager):
+async def test_failed_task(db, user, package_version, supervisor):
 
     func_serialized = pickle.dumps(failed_func)
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec="*")
     db.add(job)
     db.commit()
-    run_jobs(db)
-    new_jobs = run_tasks(db, manager)
+    supervisor.run_jobs()
+    new_jobs = supervisor.run_tasks()
     task = db.query(Task).one()
     with pytest.raises(Exception, match="some exception"):
         await new_jobs[0].wait()
 
-    check_status(db)
+    supervisor.check_status()
 
     db.refresh(task)
     assert task.status == TaskStatus.failed
@@ -362,18 +361,16 @@ async def test_failed_task(db, user, package_version, manager):
 
 
 @pytest.mark.parametrize("items_spec", ["", None])
-def test_empty_package_spec(db, user, package_version, caplog, items_spec):
+def test_empty_package_spec(db, user, package_version, caplog, items_spec, supervisor):
 
     func_serialized = pickle.dumps(func)
     job = Job(owner_id=user.id, manifest=func_serialized, items_spec=items_spec)
     db.add(job)
     db.commit()
-    run_jobs(db)
+    supervisor.run_jobs()
     db.refresh(job)
     task = db.query(Task).one_or_none()
 
-    assert "empty" in caplog.text
-    # could be job triggered from actions so we don't change state
     assert job.status == JobStatus.pending
     assert task is None
 
@@ -514,7 +511,7 @@ def test_parse_conda_spec():
         ("*", 1),
     ],
 )
-def test_filter_versions(db, user, package_version, spec, n_tasks, manager):
+def test_filter_versions(db, user, package_version, spec, n_tasks, supervisor):
 
     func_serialized = pickle.dumps(func)
     job = Job(
@@ -524,8 +521,8 @@ def test_filter_versions(db, user, package_version, spec, n_tasks, manager):
     )
     db.add(job)
     db.commit()
-    run_jobs(db)
-    run_tasks(db, manager)
+    supervisor.run_jobs()
+    supervisor.run_tasks()
     db.refresh(job)
     n_created_tasks = db.query(Task).count()
 
@@ -533,7 +530,7 @@ def test_filter_versions(db, user, package_version, spec, n_tasks, manager):
 
 
 @pytest.mark.parametrize("user_role", ["owner"])
-def test_refresh_job(auth_client, user, db, package_version, manager):
+def test_refresh_job(auth_client, user, db, package_version, supervisor):
 
     func_serialized = pickle.dumps(dummy_func)
     job = Job(
@@ -558,14 +555,15 @@ def test_refresh_job(auth_client, user, db, package_version, manager):
     assert job.status == JobStatus.pending
     assert len(job.tasks) == 1
 
-    run_jobs(db)
-    check_status(db)
+    supervisor.run_jobs()
+    supervisor.check_status()
     assert job.status == JobStatus.success
     assert len(job.tasks) == 1
 
     response = auth_client.patch(
         f"/api/jobs/{job.id}", json={"status": "pending", "force": True}
     )
+    supervisor.run_jobs()
     db.refresh(job)
     assert job.status == JobStatus.running
     assert len(job.tasks) == 2

--- a/quetz/tests/test_workers.py
+++ b/quetz/tests/test_workers.py
@@ -69,7 +69,7 @@ def threading_worker(background_tasks, dao, auth, http_session, config):
 @pytest.fixture
 def subprocess_worker(api_key, browser_session, db, config):
     SubprocessWorker._executor = None
-    worker = SubprocessWorker(api_key, browser_session, config)
+    worker = SubprocessWorker(config)
     return worker
 
 
@@ -79,8 +79,6 @@ def redis_worker(redis_ip, redis_port, redis_db, api_key, browser_session, db, c
         redis_ip,
         redis_port,
         redis_db,
-        api_key,
-        browser_session,
         config,
         no_testing=False,
     )


### PR DESCRIPTION
* create a class for monitoring jobs (supervisor), which replaces run_tasks, run_jobs etc methods
* add an option to start the supervisor in a subprocess when starting quetz
* use job owner to authorize actions/tasks