### PR TITLE
Schedule params jobs endpoint

### DIFF
--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -1084,13 +1084,15 @@ class Dao:
 
         return get_paginated_result(tasks, skip, limit)
 
-    def create_job(self, user_id, function_name, items_spec):
+    def create_job(self, user_id, job_model):
 
-        serialized = function_name.encode('ascii')
+        serialized = job_model.manifest.encode('ascii')
         job = Job(
             owner_id=user_id,
             manifest=serialized,
-            items_spec=items_spec,
+            items_spec=job_model.items_spec,
+            start_at=job_model.start_at,
+            repeat_every_seconds=job_model.repeat_every_seconds,
         )
         self.db.add(job)
         self.db.commit()

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -64,13 +64,13 @@ def get_job_or_fail(
 
     job = dao.get_job(job_id)
 
-    auth.assert_jobs(job.owner_id)
-
     if not job:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
             detail=f"Job with id {job_id} not found",
         )
+
+    auth.assert_jobs(job.owner_id)
 
     return job
 

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -52,7 +52,7 @@ def create_job(
     user = auth.assert_user()
     # only admins can create jobs through /jobs API
     auth.assert_jobs(None)
-    new_job = dao.create_job(user, job.manifest, job.items_spec)
+    new_job = dao.create_job(user, job)
     return new_job
 
 

--- a/quetz/jobs/handlers.py
+++ b/quetz/jobs/handlers.py
@@ -1,0 +1,15 @@
+from quetz.metrics import tasks as metrics_tasks
+from quetz.tasks import cleanup, indexing, mirror, reindexing
+
+JOB_HANDLERS = {
+    "synchronize": mirror.synchronize_packages,
+    "synchronize_repodata": mirror.synchronize_packages,
+    "validate_packages": indexing.validate_packages,
+    "generate_indexes": indexing.update_indexes,
+    "reindex": reindexing.reindex_packages_from_store,
+    "synchronize_metrics": metrics_tasks.synchronize_metrics_from_mirrors,
+    "pkgstore_cleanup": cleanup.cleanup_channel_db,
+    "db_cleanup": cleanup.cleanup_temp_files,
+    "pkgstore_cleanup_dry_run": cleanup.cleanup_channel_db,
+    "db_cleanup_dry_run": cleanup.cleanup_temp_files,
+}

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -122,6 +122,8 @@ class ChannelActionEnum(str, Enum):
     cleanup = 'cleanup'
     cleanup_dry_run = 'cleanup_dry_run'
 
+    # handlers for new actions should be registered in quetz.job.handlers
+
 
 class ChannelMetadata(BaseModel):
 

--- a/quetz/tasks/common.py
+++ b/quetz/tasks/common.py
@@ -6,25 +6,11 @@ from fastapi import HTTPException, status
 
 from quetz import authorization, dao, db_models
 from quetz.jobs.dao import JobsDao
-from quetz.metrics import tasks as metrics_tasks
 from quetz.rest_models import ChannelActionEnum
 
-from . import assertions, cleanup, indexing, mirror, reindexing
+from . import assertions
 
 logger = logging.getLogger("quetz")
-
-ACTION_HANDLERS = {
-    "synchronize": mirror.synchronize_packages,
-    "synchronize_repodata": mirror.synchronize_packages,
-    "validate_packages": indexing.validate_packages,
-    "generate_indexes": indexing.update_indexes,
-    "reindex": reindexing.reindex_packages_from_store,
-    "synchronize_metrics": metrics_tasks.synchronize_metrics_from_mirrors,
-    "pkgstore_cleanup": cleanup.cleanup_channel_db,
-    "db_cleanup": cleanup.cleanup_temp_files,
-    "pkgstore_cleanup_dry_run": cleanup.cleanup_channel_db,
-    "db_cleanup_dry_run": cleanup.cleanup_temp_files,
-}
 
 
 def assert_channel_action(action, channel):

--- a/quetz/testing/mockups.py
+++ b/quetz/testing/mockups.py
@@ -1,11 +1,10 @@
-import pickle
 from typing import Callable, Optional, Union
 
 import requests
 
 from quetz.config import Config
 from quetz.dao import Dao
-from quetz.tasks.workers import job_wrapper, prepare_arguments
+from quetz.tasks.workers import job_wrapper
 
 
 class TestWorker:
@@ -34,11 +33,5 @@ class TestWorker:
         if self.session:
             resources['session'] = self.session
 
-        if isinstance(func, bytes):
-            callable_func = pickle.loads(func)
-        else:
-            callable_func = func
-
-        extra_kwargs = prepare_arguments(callable_func, **resources)
-        kwargs.update(extra_kwargs)
+        kwargs.update(resources)
         job_wrapper(func, self.config, *args, **kwargs)


### PR DESCRIPTION
* periodic job (it will re-run on all matching package versions each time)

```
curl -X POST localhost:8000/api/jobs  -d '{"items_spec": "test-package", "manifest": "quetz-transmutation:transmutation", "repeat_every_seconds": 20}' -H "X-api-key: ${QUETZ_API_KEY}"    
```

* delayed job

```
curl -X POST localhost:8000/api/jobs -d '{"items_spec": "test-package", "manifest": "quetz-transmutation:transmutation", "start_at": "2021-03-03T11:27"}'  -H "X-api-key: ${QUETZ_API_KEY}"    
```

* we don't  store any more pickled function in the db, just the name of the function (and plugin if not a builtin function)