### PR TITLE
Update harvester plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           for f in ./plugins/quetz_*
           do
             echo "Testing plugin" $f
-            pip install $f
+            quetz plugin install $f
             pytest -v $f
           done
       - uses: codecov/codecov-action@v1

--- a/plugins/quetz_harvester/README.md
+++ b/plugins/quetz_harvester/README.md
@@ -17,5 +17,14 @@ pip install .
 
 ## Using
 
-After installing the package and running a `harvest` job, each package will have an additional file added to the packagestore (`channel/metadata/subdir/package-name.json`).
+After installing the package run the `harvest` job using the standard /jobs endpoint in quetz:
+
+```
+QUETZ_API_KEY=... # setup you api key retrieved through the quetz fronted
+curl -X POST localhost:8000/api/jobs  -d '{"items_spec": "*", "manifest": "quetz-harvester:harvest"}' -H "X-api-key: ${QUETZ_API_KEY}"
+```
+
+it will run the `harvest` job on ALL package files on the server.
+
+Each package will have an additional file added to the packagestore (`channel/metadata/subdir/package-name.json`).
 You can access that file from the URL: `http://quetz/channels/channel/metadata/subdir/package-name.json`.

--- a/plugins/quetz_harvester/quetz_harvester/jobs.py
+++ b/plugins/quetz_harvester/quetz_harvester/jobs.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Optional
 
@@ -7,6 +8,8 @@ from pydantic import BaseModel, Field
 
 from quetz.dao import Dao
 from quetz.pkgstores import PackageStore
+
+logger = logging.getLogger("quetz.plugins")
 
 
 class PackageSpec(BaseModel):
@@ -18,21 +21,20 @@ def harvest(package_version: dict, config, pkgstore: PackageStore, dao: Dao):
     channel: str = package_version["channel_name"]
     platform = package_version["platform"]
 
-    print(f"Harvesting: {filename}, {channel}, {platform}")
+    logger.debug(f"Harvesting: {filename}, {channel}, {platform}")
     # TODO figure out how to handle properly either .conda or .tar.bz2
     if not filename.endswith('.tar.bz2'):
         return
 
     fh = pkgstore.serve_path(channel, Path(platform) / filename)
 
-    print("Harvesting ... ")
     try:
         result = libc_harvest(fh)
     except Exception as e:
-        print(f"Exception caught in harvesting: {str(e)}")
+        logger.exception(f"Exception caught in harvesting {filename}: {str(e)}")
         return
 
-    print(f"Uploading harvest result for {channel}/{platform}/{filename}")
+    logger.debug(f"Uploading harvest result for {channel}/{platform}/{filename}")
 
     pkgstore.add_file(
         json.dumps(result, indent=4, sort_keys=True),

--- a/plugins/quetz_harvester/quetz_harvester/main.py
+++ b/plugins/quetz_harvester/quetz_harvester/main.py
@@ -1,8 +1,0 @@
-import quetz
-
-from .api import router
-
-
-@quetz.hookimpl
-def register_router():
-    return router

--- a/plugins/quetz_harvester/setup.py
+++ b/plugins/quetz_harvester/setup.py
@@ -5,6 +5,8 @@ setup(
     # you should install libcflib using
     # $ pip install git+https://git@github.com/regro/libcflib@master --no-deps
     install_requires=["quetz", "libcflib"],
-    entry_points={"quetz": ["quetz-harvester = quetz_harvester.main"]},
+    entry_points={
+        "quetz.jobs": ["quetz-harvester=quetz_harvester.jobs"],
+    },
     packages=["quetz_harvester"],
 )

--- a/plugins/quetz_harvester/tests/test_main.py
+++ b/plugins/quetz_harvester/tests/test_main.py
@@ -1,24 +1,20 @@
 from pathlib import Path
 
-import pytest
-from httpx import AsyncClient
-
 from quetz.db_models import PackageVersion
 from quetz.jobs.models import Job, Task, TaskStatus
 
 
-@pytest.mark.asyncio
-async def test_harvest_endpoint_and_job(
-    auth_client, db, config, supervisor, package_version, app, channel_name
+def test_harvest_endpoint_and_job(
+    api_key, auth_client, db, config, supervisor, package_version, app, channel_name
 ):
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.put("/api/harvester", json={"package_spec": "*"})
+    response = auth_client.post(
+        "/api/jobs", json={"items_spec": "*", "manifest": "quetz-harvester:harvest"}
+    )
 
-    assert response.status_code == 200
+    assert response.status_code == 201
     supervisor.run_jobs()
-    new_jobs = supervisor.run_tasks()
-    await new_jobs[0].wait()
+    supervisor.run_tasks()
 
     supervisor.check_status()
 

--- a/quetz/jobs/rest_models.py
+++ b/quetz/jobs/rest_models.py
@@ -41,7 +41,7 @@ def parse_job_manifest(function_name):
                 f"invalid function {function_name}: "
                 f"plugin {plugin_name} not installed"
             )
-        job_module = entry_points[0].load()
+        job_module = entry_points[0].load(require=False)
         try:
             return getattr(job_module, job_name)
         except AttributeError:


### PR DESCRIPTION
* remove harvest api endpoint
* register quetz.jobs entrypoint (which allows to run the jobs using quetz /jobs endpoint)
* use the testworker for testing (which simplifies and speeds up running tests)

example:

```
curl -X POST localhost:8000/api/jobs    -H "X-api-key: ${QUETZ_API_KEY}"   \
   -d '{"items_spec": "test-package", "manifest": "quetz-harvester:harvest"}' 
```