### PR TITLE
set upper bound for sqlalchemy dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - authlib
   - psycopg2
   - httpx=0.16.0
-  - sqlalchemy
+  - sqlalchemy<1.4.0
   - sqlalchemy-utils
   - sqlite
   - python-multipart


### PR DESCRIPTION
Sqlalchemy has recently released version 1.4. This results in an
import error:

```
$ quetz run test_quetz --copy-conf ./dev_config.toml --dev --reload
Traceback (most recent call last):
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/bin/quetz", line 33, in <module>
    sys.exit(load_entry_point('quetz', 'console_scripts', 'quetz')())
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/bin/quetz", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/export/scratch1/hendriks/projects/quetz/quetz/cli.py", line 22, in <module>
    from sqlalchemy_utils.functions import database_exists
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy_utils/__init__.py", line 1, in <module>
    from .aggregates import aggregated  # noqa
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy_utils/aggregates.py", line 372, in <module>
    from .functions.orm import get_column_key
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy_utils/functions/__init__.py", line 1, in <module>
    from .database import (  # noqa
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy_utils/functions/database.py", line 11, in <module>
    from .orm import quote
  File "/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy_utils/functions/orm.py", line 14, in <module>
    from sqlalchemy.orm.query import _ColumnEntity
ImportError: cannot import name '_ColumnEntity' from 'sqlalchemy.orm.query' (/export/scratch1/hendriks/miniconda3/envs/quetz/lib/python3.8/site-packages/sqlalchemy/orm/query.py)
```

See also:
https://stackoverflow.com/questions/66644975/importerror-cannot-import-name-columnentity-from-sqlalchemy-orm-query

Upper bounding sqlalchemy to < 1.4 solves the issue.