### PR TITLE
Add gitlab authenticator

### DIFF
--- a/docs/source/deploying/authenticators.rst
+++ b/docs/source/deploying/authenticators.rst
@@ -24,6 +24,12 @@ Github
 
 .. autoclass:: quetz.authentication.github.GithubAuthenticator
 
+Gitlab
+^^^^^^
+
+.. autoclass:: quetz.authentication.gitlab.GitlabAuthenticator
+
+
 Google
 ^^^^^^
 

--- a/quetz/authentication/gitlab.py
+++ b/quetz/authentication/gitlab.py
@@ -1,0 +1,65 @@
+from .oauth2 import OAuthAuthenticator
+
+
+class GitlabAuthenticator(OAuthAuthenticator):
+    """Use Gitlab account to authenticate users with Quetz.
+
+    To enable add the following to the configuration file:
+
+    .. code::
+
+      [gitlab]
+      client_id = "fde330aef1fbe39991"
+      client_secret = "03728444a12abff17e9444fd231b4379d58f0b"
+
+    The above will use `<https://gitlab.com>`_. You can specify a self-hosted
+    GitLab instance using the ``url`` parameter:
+
+    .. code::
+
+      [gitlab]
+      url = "https://gitlab.mydomain.org"
+      client_id = "fde330aef1fbe39991"
+      client_secret = "03728444a12abff17e9444fd231b4379d58f0b"
+
+    You can obtain ``client_id`` and ``client_secret`` by registering your
+    application with Gitlab at this URL:
+    `<https://gitlab.com/-/profile/applications>`_ or
+    `<https://gitlab.mydomain.org/admin/applications>`_
+    if using a self-hosted GitLab instance.
+    Select ``openid`` as scope.
+    """
+
+    provider = "gitlab"
+
+    # oauth client params
+    scope = 'openid'
+
+    # endpoint urls
+    validate_token_url = "user"
+
+    async def userinfo(self, request, token):
+        resp = await self.client.get('/oauth/userinfo', token=token)
+        profile = resp.json()
+        gitlab_profile = {
+            "id": profile["sub"],
+            "name": profile["name"],
+            "avatar_url": profile['picture'],
+            "login": profile["nickname"],
+        }
+        return gitlab_profile
+
+    def configure(self, config):
+        if config.configured_section("gitlab"):
+            self.access_token_url = f'{config.gitlab_url}/oauth/token'
+            self.authorize_url = f'{config.gitlab_url}/oauth/authorize'
+            self.api_base_url = f'{config.gitlab_url}/api/v4'
+            self.revoke_url = f'{config.gitlab_url}/oauth/applications'
+            self.client_id = config.gitlab_client_id
+            self.client_secret = config.gitlab_client_secret
+            self.is_enabled = True
+        else:
+            self.is_enabled = False
+
+        # call the configure of base class to set default_channel and default role
+        super().configure(config)

--- a/quetz/basic_frontend/index.html
+++ b/quetz/basic_frontend/index.html
@@ -49,8 +49,10 @@
 <body>
 <h1>Quetz</h1>
 <a href="/auth/github/login" style="margin-right: 100px" id="github_login">login with github</a>
+<a href="/auth/gitlab/login" style="margin-right: 100px" id="gitlab_login">login with gitlab</a>
 <a href="/auth/google/login" style="margin-right: 100px" id="google_login">login with google</a>
 <a href="/auth/github/revoke" style="margin-right: 100px" id="revoke">revoke github</a>
+<a href="/auth/gitlab/revoke" style="margin-right: 100px" id="revoke">revoke gitlab</a>
 <a href="/auth/google/revoke" style="margin-right: 100px" id="revoke">revoke google</a>
 
 <div class="modal">

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -94,6 +94,15 @@ class Config:
             required=False,
         ),
         ConfigSection(
+            "gitlab",
+            [
+                ConfigEntry("url", str, default="https://gitlab.com"),
+                ConfigEntry("client_id", str),
+                ConfigEntry("client_secret", str),
+            ],
+            required=False,
+        ),
+        ConfigSection(
             "sqlalchemy",
             [
                 ConfigEntry("database_url", str),

--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -131,11 +131,13 @@ def register(app):
     auth_registry = AuthenticatorRegistry()
     google_login_available = auth_registry.is_registered("google")
     github_login_available = auth_registry.is_registered("github")
+    gitlab_login_available = auth_registry.is_registered("gitlab")
 
     config_data = {
         "appName": "Quetz – the fast conda package server!",
         "baseUrl": "/jlabmock/",
         "github_login_available": github_login_available,
+        "gitlab_login_available": gitlab_login_available,
         "google_login_available": google_login_available,
     }
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -58,6 +58,7 @@ from quetz import (
 )
 from quetz.authentication import AuthenticatorRegistry, BaseAuthenticator
 from quetz.authentication import github as auth_github
+from quetz.authentication import gitlab as auth_gitlab
 from quetz.authentication import google as auth_google
 from quetz.authentication.jupyterhub import JupyterhubAuthenticator
 from quetz.authentication.pam import PAMAuthenticator
@@ -159,6 +160,7 @@ pkgstore_support_url = hasattr(pkgstore, 'url')
 
 builtin_authenticators: List[Type[BaseAuthenticator]] = [
     auth_github.GithubAuthenticator,
+    auth_gitlab.GitlabAuthenticator,
     auth_google.GoogleAuthenticator,
     JupyterhubAuthenticator,
     PAMAuthenticator,

--- a/quetz_frontend/src/components/Header.vue
+++ b/quetz_frontend/src/components/Header.vue
@@ -19,6 +19,11 @@
             Sign In Via Github
           </cv-button>
         </template>
+        <template v-if="gitlab_login">
+          <cv-button v-on:click="signinGitlab">
+            Sign In Via Gitlab
+          </cv-button>
+        </template>
         <template v-if="google_login">
           <cv-button v-on:click="signinGoogle">
             Sign In Via Google
@@ -64,12 +69,14 @@
         name: '',
         avatar_url: undefined,
         github_login: false,
+        gitlab_login: false,
         google_login: false,
       };
     },
     created() {
       this.me();
       this.check_github_login();
+      this.check_gitlab_login();
       this.check_google_login();
     //  TODO: get enabled login routes
     },
@@ -77,6 +84,10 @@
       signinGithub() {
         window.location.href = "/auth/github/login";
         console.log("Signing in via github");
+      },
+      signinGitlab() {
+        window.location.href = "/auth/gitlab/login";
+        console.log("Signing in via gitlab");
       },
       signinGoogle() {
         window.location.href = "/auth/google/login";
@@ -105,6 +116,14 @@
         }).catch((err) => {
           console.log(err);
           this.github_login = false;
+        })
+      },
+      check_gitlab_login() {
+        fetch("/auth/gitlab/enabled").then((msg) => {
+          this.gitlab_login = msg.status === 200;
+        }).catch((err) => {
+          console.log(err);
+          this.gitlab_login = false;
         })
       },
       check_google_login() {


### PR DESCRIPTION
This PR adds GitLab as authenticator.

I realise I should have created an issue before to make this PR. This is something I need because we gonna try to deploy this internally.
I think this authenticator can be quite useful because it's quite common to have a self-hosted GitLab instance.

I didn't see any test for the GitHub or google authenticators, so there are none in this PR (it depends on the oauth2 one).

I tested the authentication manually both with gitlab.com and a self-hosted GitLab instance. 