### PR TITLE
Fix read of closed file with fsspec 0.9.0

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -136,7 +136,7 @@ class LocalStore(PackageStore):
         )
 
     def serve_path(self, channel, src):
-        return self.fs.open(path.join(self.channels_dir, channel, src)).f
+        return self.fs.open(path.join(self.channels_dir, channel, src))
 
     def list_files(self, channel: str):
         channel_dir = os.path.join(self.channels_dir, channel)


### PR DESCRIPTION
With fsspec 0.9.0, running `http http://localhost:8000/get/mychannel/noarch/repodata.json` returned:

```
http: error: ChunkedEncodingError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```

Error raised on the server:

```
  File "/Users/benjaminbertrand/Dev/conda/quetz/quetz/main.py", line 1600, in iter_chunks
    data = fid.read(chunk_size)
ValueError: read of closed file
```

The issue is explained here: https://github.com/intake/filesystem_spec/issues/607

> However, when you select the f attribute and forget the original LocalFileOpener, the latter gets garbage-collected. This didn't used to matter, but now the superclass IOBase calls close - which closes the underlying file too.

The current fix works with fsspec 0.8.7 as well, so I didn't add a minimum version in the environment.yml.