### PR TITLE
Add Dockerfile and GitHub Workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,44 @@
+name: docker build and push
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: mambaorg/quetz
+    steps:
+      - name: Set Docker image for main branch
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo "DOCKER_IMAGES=${IMAGE_NAME}:latest" >> $GITHUB_ENV
+
+      - name: Set Docker image for tag
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        run: echo "DOCKER_IMAGES=${IMAGE_NAME}:latest,${IMAGE_NAME}:${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Show docker images
+        run: echo $DOCKER_IMAGES
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.DOCKER_IMAGES }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,21 @@
+name: test docker build
+
+on:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true
+          tags: mambaorg/quetz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Build the frontend
+FROM node:14 as node
+
+COPY quetz_frontend /quetz_frontend
+RUN cd /quetz_frontend \
+  && npm install \
+  && npm run build
+
+# Build conda environment
+FROM condaforge/mambaforge:4.9.2-7 as conda
+
+COPY environment.yml /tmp/environment.yml
+RUN CONDA_COPY_ALWAYS=true mamba env create -p /env -f /tmp/environment.yml \
+  && conda clean -afy
+
+COPY . /code
+RUN conda run -p /env python -m pip install --no-deps /code
+
+# Create image
+FROM debian:buster-slim
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+COPY --from=node /quetz_frontend/dist /quetz-frontend
+COPY --from=conda /env /env
+
+# Set WORKDIR to /tmp because quetz always creates a quetz.log file
+# in the current directory
+WORKDIR /tmp
+ENV PATH /env/bin:$PATH
+EXPOSE 8000
+
+# The following command assumes that a deployment has been initialized
+# in the /quetz-deployment volume
+CMD ["quetz", "start", "/quetz-deployment", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
I know there is a Dockerfile under the docker directory, but it is for development.
This Dockerfile is intended more for production. It builds an image with both the frontend and conda environemnent using a multi-stages build to keep the final image size small.

I also added a GitHub workflow to build and push the image:

- The image `mambaorg/quetz:latest` is built and pushed for every commit to the master branch.
- When pushing a tag, the image is tagged with it (`mambaorg/quetz:<tag>`).
- For PR, the image is only built, but not pushed.

For the workflow to work, the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets shall be defined for the repository.