### PR TITLE
Don't serve relative paths.

### DIFF
--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -110,6 +110,8 @@ def static(
                 return HTMLResponse(content=index_rendered, status_code=200)
             else:
                 return FileResponse(path=os.path.join(frontend_dir, "index.html"))
+    elif ".." in resource:# Don't serve relative paths
+        return FileResponse(path=os.path.join(frontend_dir, "index.html"))
     else:
         return FileResponse(path=os.path.join(frontend_dir, resource))
 

--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -110,7 +110,7 @@ def static(
                 return HTMLResponse(content=index_rendered, status_code=200)
             else:
                 return FileResponse(path=os.path.join(frontend_dir, "index.html"))
-    elif ".." in resource: # Don't serve relative paths
+    elif ".." in resource:  # Don't serve relative paths
         return FileResponse(path=os.path.join(frontend_dir, "index.html"))
     else:
         return FileResponse(path=os.path.join(frontend_dir, resource))

--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -110,7 +110,7 @@ def static(
                 return HTMLResponse(content=index_rendered, status_code=200)
             else:
                 return FileResponse(path=os.path.join(frontend_dir, "index.html"))
-    elif ".." in resource:# Don't serve relative paths
+    elif ".." in resource: # Don't serve relative paths
         return FileResponse(path=os.path.join(frontend_dir, "index.html"))
     else:
         return FileResponse(path=os.path.join(frontend_dir, resource))


### PR DESCRIPTION
I noticed a security bug where Quetz will serve files outside of the quetz directory including root directories. Example(number of ".." may vary on your instance):

`curl --path-as-is http://quetzserver:8000/../../../../../../../../../../../../etc/passwd`

Returns my /etc/passwd file.

I was able to patch this on my instance by modifying quetz/frontend.py to handle the case where a relative path was given to static(), but I am not sure this is the best fix or a comprehensive solution.
