### PR TITLE
Serve only files below frontend_dir using os.path.commonpath

### DIFF
--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -96,9 +96,9 @@ def _under_frontend_dir(path):
     NOTE: os.path.abspath may seem unnecessary, but os.path.commonpath does not
     appear to handle relative paths as you would expect:
 
-    >>> os.path.commonpath([os.path.abspath('../quetz/quetz'), os.path.abspath('quetz')])
+    >>> commonpath([abspath('../quetz/quetz'), abspath('quetz')])
     '/home/username/quetz/quetz'
-    >>> os.path.commonpath(['../quetz/quetz', 'quetz'])
+    >>> commonpath(['../quetz/quetz', 'quetz'])
     ''
     """
     path = os.path.abspath(path)

--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -94,7 +94,7 @@ def _under_frontend_dir(path):
     Check that path is under frontend_dir
 
     NOTE: os.path.abspath may seem unnecessary, but os.path.commonpath does not
-    appear to handle relative paths you would expect:
+    appear to handle relative paths as you would expect:
 
     >>> os.path.commonpath([os.path.abspath('../quetz/quetz'), os.path.abspath('quetz')])
     '/home/username/quetz/quetz'

--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -128,7 +128,7 @@ def static(
                 return HTMLResponse(content=index_rendered, status_code=200)
             else:
                 return FileResponse(path=os.path.join(frontend_dir, "index.html"))
-    elif not _under_frontend_dir(resource):  # Don't serve relative paths
+    elif not _under_frontend_dir(resource):
         return FileResponse(path=os.path.join(frontend_dir, "index.html"))
     else:
         return FileResponse(path=os.path.join(frontend_dir, resource))


### PR DESCRIPTION
This will use `os.path.commonpath` to ensure any static files being served are under `frontend_dir`. Currently we are just checking for `..` in the filename (see  #395), which should work, but this methods utilizes the `os.path` library which should provide a cleaner/more robust solution, addressing #396.