### PR TITLE
start collecting email addresses for users

### DIFF
--- a/dev_config.toml
+++ b/dev_config.toml
@@ -1,5 +1,6 @@
 [github]
 # Register the app here: https://github.com/settings/applications/new
+# Use a callback URL like `http://localhost:8000/auth/github/authorize`
 client_id = "37cdbb80c7733e2a1831"
 client_secret = "75e648e981545902ab7802de94e2f2707c8e0ff8"
 

--- a/docs/source/deploying/authenticators.rst
+++ b/docs/source/deploying/authenticators.rst
@@ -7,6 +7,13 @@ by services such as Github and Google. This means that you can configure Quetz t
 users log in with their Github accounts. Quetz also supports the PAM-based authentication which
 uses local Unix users for authentication.
 
+.. warning::
+    While it is possible to register and use multiple authenticators at once, it is heavily discouraged
+    and a warning will be printed. Currently quetz does not automatically merge accounts based on email
+    addresses and usernames from different auth providers can overlap.
+
+    A warning will be printed when running quetz with multiple activated auth providers.
+
 Built-in authenticators
 -----------------------
 

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -54,6 +54,8 @@ Configure default user permissions, creating default channel and super-admin per
    default_role = "member"
    # create a default channel for new users named {username}
    create_default_channel = false
+   # wether to collect email addresses when users register
+   collect_emails = false
 
 You can use one of the following options to configure privileged users:
 

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -67,7 +67,7 @@ def user_profile_changed(user, identity, profile: 'base.UserProfile'):
         or user.profile.name != profile['name']
         or user.profile.avatar_url != profile['avatar_url']
         or set((e.verified, e.primary, e.email) for e in user.emails)
-        != set((e['verified'], e['primary'], e['email']) for e in profile['emails'])
+        != set((e['verified'], e['primary'], e['email']) for e in profile.get('emails', []))
     ):
         return True
 

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -10,7 +10,7 @@ from quetz import rest_models
 from quetz.authorization import OWNER
 from quetz.config import Config
 from quetz.dao import Dao
-from quetz.db_models import Channel, Identity, User, Email
+from quetz.db_models import Channel, Email, Identity, User
 from quetz.errors import ValidationError
 
 from . import base
@@ -90,9 +90,7 @@ def update_user_from_profile(
         if not e["verified"]:
             continue
 
-        user_email = (
-            db.query(Email).filter(Email.email == e["email"]).one_or_none()
-        )
+        user_email = db.query(Email).filter(Email.email == e["email"]).one_or_none()
         if user_email and user_email.user_id != user.id:
             raise IntegrityError(
                 f"User {user.profile.name} already registered"

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -67,7 +67,9 @@ def user_profile_changed(user, identity, profile: 'base.UserProfile'):
         or user.profile.name != profile['name']
         or user.profile.avatar_url != profile['avatar_url']
         or set((e.verified, e.primary, e.email) for e in user.emails)
-        != set((e['verified'], e['primary'], e['email']) for e in profile.get('emails', []))
+        != set(
+            (e['verified'], e['primary'], e['email']) for e in profile.get('emails', [])
+        )
     ):
         return True
 

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -10,7 +10,7 @@ from quetz import rest_models
 from quetz.authorization import OWNER
 from quetz.config import Config
 from quetz.dao import Dao
-from quetz.db_models import Channel, Identity, User, UserEmail
+from quetz.db_models import Channel, Identity, User, Email
 from quetz.errors import ValidationError
 
 from . import base
@@ -91,7 +91,7 @@ def update_user_from_profile(
             continue
 
         user_email = (
-            db.query(UserEmail).filter(UserEmail.email == e["email"]).one_or_none()
+            db.query(Email).filter(Email.email == e["email"]).one_or_none()
         )
         if user_email and user_email.user_id != user.id:
             raise IntegrityError(
@@ -106,7 +106,7 @@ def update_user_from_profile(
             user_email.primary = True if e["primary"] else False
         else:
             emails.append(
-                UserEmail(
+                Email(
                     email=e["email"],
                     verified=e["verified"],
                     primary=e["primary"],

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -84,7 +84,6 @@ def update_user_from_profile(
     user.profile.name = profile['name']
     user.profile.avatar_url = profile['avatar_url']
 
-    # TODO modify emails here
     # check if any email already registered
     emails = []
     for e in profile.get('emails', []):

--- a/quetz/authentication/base.py
+++ b/quetz/authentication/base.py
@@ -19,7 +19,7 @@ else:
 from . import auth_dao
 
 
-class UserEmail(TypedDict):
+class Email(TypedDict):
 
     email: str
     verified: Boolean
@@ -32,7 +32,7 @@ class UserProfile(TypedDict):
     name: str
     avatar_url: str
     login: str
-    emails: List[UserEmail]
+    emails: List[Email]
 
 
 class UserName(TypedDict):

--- a/quetz/authentication/base.py
+++ b/quetz/authentication/base.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Dict, List, Optional, Type, Union
 
 from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.sql.sqltypes import Boolean
 from starlette.responses import RedirectResponse
 
 from quetz.authorization import ServerRole
@@ -18,12 +19,20 @@ else:
 from . import auth_dao
 
 
+class UserEmail(TypedDict):
+
+    email: str
+    verified: Boolean
+    primary: Boolean
+
+
 class UserProfile(TypedDict):
 
     id: str
     name: str
     avatar_url: str
     login: str
+    emails: List[UserEmail]
 
 
 class UserName(TypedDict):
@@ -113,6 +122,7 @@ class BaseAuthenticationHandlers:
             "id": user_data["username"],
             "name": user_data["username"],
             "avatar_url": "",
+            "emails": [],
         }
 
         profile: UserProfile = user_data.get("profile", default_profile)

--- a/quetz/authentication/github.py
+++ b/quetz/authentication/github.py
@@ -18,6 +18,7 @@ class GithubAuthenticator(OAuthAuthenticator):
     """
 
     provider = "github"
+    collect_emails = False
 
     # oauth client params
     access_token_url = 'https://github.com/login/oauth/access_token'
@@ -46,8 +47,6 @@ class GithubAuthenticator(OAuthAuthenticator):
             self.is_enabled = True
             if config.configured_section("users"):
                 self.collect_emails = config.users_collect_emails
-            else:
-                self.collect_emails = False
 
         else:
             self.is_enabled = False

--- a/quetz/authentication/github.py
+++ b/quetz/authentication/github.py
@@ -33,6 +33,10 @@ class GithubAuthenticator(OAuthAuthenticator):
         resp = await self.client.get('user', token=token)
         profile = resp.json()
 
+        if self.collect_emails:
+            emails = await self.client.get('user/emails', token=token)
+            profile["emails"] = emails.json()
+
         return profile
 
     def configure(self, config):
@@ -40,6 +44,11 @@ class GithubAuthenticator(OAuthAuthenticator):
             self.client_id = config.github_client_id
             self.client_secret = config.github_client_secret
             self.is_enabled = True
+            if config.configured_section("users"):
+                self.collect_emails = config.users_collect_emails
+            else:
+                self.collect_emails = False
+
         else:
             self.is_enabled = False
 

--- a/quetz/authentication/gitlab.py
+++ b/quetz/authentication/gitlab.py
@@ -53,8 +53,6 @@ class GitlabAuthenticator(OAuthAuthenticator):
         }
 
         # https://docs.gitlab.com/ee/integration/openid_connect_provider.html#shared-information
-        # note we're not checking if the email has been verified here...
-        # which we could do by looking at `profile["email_verified"]`.
         if self.collect_emails:
             emails = await self.client.get('/api/v4/user/emails', token=token)
             emails_res = []
@@ -67,6 +65,10 @@ class GitlabAuthenticator(OAuthAuthenticator):
             )
 
             for e in emails.json():
+                # there is a bug in gitlab so this should never be true (currently)
+                if e["email"] == profile["email"]:
+                    continue
+
                 x = {
                     "email": e["email"],
                     "primary": False,

--- a/quetz/authentication/gitlab.py
+++ b/quetz/authentication/gitlab.py
@@ -27,8 +27,9 @@ class GitlabAuthenticator(OAuthAuthenticator):
     `<https://gitlab.com/-/profile/applications>`_ or
     `<https://gitlab.mydomain.org/admin/applications>`_
     if using a self-hosted GitLab instance.
-    Select ``openid`` as scope. If you want to collect email addresses, 
-    make sure to also select ``email`` as scope in the Gitlab interface.
+    Select ``openid`` as scope. If you want to collect email addresses,
+    make sure to also select ``email``, ``profile`` and ``read_user`` as scope
+    in the Gitlab interface.
     """
 
     provider = "gitlab"
@@ -88,7 +89,7 @@ class GitlabAuthenticator(OAuthAuthenticator):
             self.is_enabled = True
             if config.configured_section("users"):
                 self.collect_emails = config.users_collect_emails
-                self.scope = 'openid email read_user'                
+                self.scope = 'openid email read_user'
 
         else:
             self.is_enabled = False

--- a/quetz/authentication/google.py
+++ b/quetz/authentication/google.py
@@ -30,6 +30,8 @@ class GoogleAuthenticator(OAuthAuthenticator):
     revoke_url = 'https://myaccount.google.com/permissions'
     validate_token_url = 'https://openidconnect.googleapis.com/v1/userinfo'
 
+    collect_emails = False
+
     async def userinfo(self, request, token):
         profile = await self.client.parse_id_token(request, token)
 
@@ -59,8 +61,6 @@ class GoogleAuthenticator(OAuthAuthenticator):
             self.is_enabled = True
             if config.configured_section("users"):
                 self.collect_emails = config.users_collect_emails
-            else:
-                self.collect_emails = False
 
         else:
             self.is_enabled = False

--- a/quetz/authentication/google.py
+++ b/quetz/authentication/google.py
@@ -51,7 +51,7 @@ class GoogleAuthenticator(OAuthAuthenticator):
                     "verified": profile["email_verified"],
                 }
             ]
-        print(github_profile)
+
         return github_profile
 
     def configure(self, config: Config):

--- a/quetz/authentication/google.py
+++ b/quetz/authentication/google.py
@@ -37,8 +37,19 @@ class GoogleAuthenticator(OAuthAuthenticator):
             "id": profile["sub"],
             "name": profile["name"],
             "avatar_url": profile['picture'],
+            "email": profile["email"],
             "login": profile["email"],
         }
+
+        if self.collect_emails:
+            github_profile["emails"] = [
+                {
+                    "email": profile["email"],
+                    "primary": True,
+                    "verified": profile["email_verified"],
+                }
+            ]
+        print(github_profile)
         return github_profile
 
     def configure(self, config: Config):
@@ -46,6 +57,11 @@ class GoogleAuthenticator(OAuthAuthenticator):
             self.client_id = config.google_client_id
             self.client_secret = config.google_client_secret
             self.is_enabled = True
+            if config.configured_section("users"):
+                self.collect_emails = config.users_collect_emails
+            else:
+                self.collect_emails = False
+
         else:
             self.is_enabled = False
 

--- a/quetz/authentication/oauth2.py
+++ b/quetz/authentication/oauth2.py
@@ -92,6 +92,7 @@ class OAuthAuthenticator(BaseAuthenticator):
 
     async def authenticate(self, request, data=None, dao=None, config=None):
         token = await self.client.authorize_access_token(request)
+
         profile = await self.userinfo(request, token)
 
         username = profile["login"]

--- a/quetz/authentication/pam.py
+++ b/quetz/authentication/pam.py
@@ -7,14 +7,14 @@ from typing import List, Optional
 import pamela
 from fastapi import Request
 
-from quetz.authentication.base import SimpleAuthenticator, UserProfile
+from quetz.authentication.base import BaseAuthenticator, FormHandlers, UserProfile
 from quetz.authorization import ServerRole
 from quetz.config import Config, ConfigEntry, ConfigSection
 
 logger = logging.getLogger("quetz")
 
 
-class PAMAuthenticator(SimpleAuthenticator):
+class PAMAuthenticator(BaseAuthenticator):
     """Use PAM to authenticate with local system users.
 
     To enable add the following to your configuration file:
@@ -44,6 +44,7 @@ class PAMAuthenticator(SimpleAuthenticator):
     """
 
     provider: str = 'pam'
+    handler_cls = FormHandlers
 
     service: str = "login"
     encoding: str = 'utf8'

--- a/quetz/authentication/registry.py
+++ b/quetz/authentication/registry.py
@@ -38,5 +38,11 @@ class AuthenticatorRegistry:
             f"of class {auth.__class__.__name__} registered"
         )
 
+        if len(self.enabled_authenticators) > 1:
+            logger.warn(
+                "You have registered multiple authentication providers."
+                "Please note that this is currently discouraged in production setups!"
+            )
+
     def is_registered(self, provider_name: str):
         return provider_name in self.enabled_authenticators

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -166,6 +166,7 @@ class Config:
                 ConfigEntry("maintainers", list, default=list),
                 ConfigEntry("members", list, default=list),
                 ConfigEntry("default_role", str, required=False),
+                ConfigEntry("collect_emails", bool, default=False, required=False),
                 ConfigEntry(
                     "create_default_channel", bool, default=False, required=False
                 ),

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -26,13 +26,13 @@ from .db_models import (
     Channel,
     ChannelMember,
     ChannelMirror,
+    Email,
     Identity,
     Package,
     PackageMember,
     PackageVersion,
     Profile,
     User,
-    Email,
 )
 from .jobs.models import Job, JobStatus, Task, TaskStatus
 from .metrics.db_models import (

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -32,7 +32,7 @@ from .db_models import (
     PackageVersion,
     Profile,
     User,
-    UserEmail,
+    Email,
 )
 from .jobs.models import Job, JobStatus, Task, TaskStatus
 from .metrics.db_models import (
@@ -1023,7 +1023,7 @@ class Dao:
         avatar_url: str,
         role: Optional[str],
         exist_ok: bool = False,
-        emails: Optional[List['auth_base.UserEmail']] = None,
+        emails: Optional[List['auth_base.Email']] = None,
     ):
         """create a user with profile and role
 
@@ -1042,8 +1042,8 @@ class Dao:
             if emails:
                 for e in emails:
                     user_email = (
-                        self.db.query(UserEmail)
-                        .filter(UserEmail.email == e["email"])
+                        self.db.query(Email)
+                        .filter(Email.email == e["email"])
                         .one_or_none()
                     )
                     if user_email:
@@ -1073,7 +1073,7 @@ class Dao:
                 # we only store verified emails
                 if not email["verified"]:
                     continue
-                user_email = UserEmail(
+                user_email = Email(
                     provider=provider,
                     identity_id=identity_id,
                     email=email["email"],

--- a/quetz/db_models.py
+++ b/quetz/db_models.py
@@ -41,7 +41,7 @@ class User(Base):
 
     identities = relationship('Identity', back_populates='user', uselist=True)
     emails = relationship(
-        'UserEmail', back_populates='user', uselist=True, cascade="all,delete-orphan"
+        'Email', back_populates='user', uselist=True, cascade="all,delete-orphan"
     )
     profile = relationship(
         'Profile', uselist=False, back_populates='user', cascade="all,delete-orphan"
@@ -57,8 +57,8 @@ class User(Base):
         return db.query(cls).filter(cls.username == name).first()
 
 
-class UserEmail(Base):
-    __tablename__ = "user_emails"
+class Email(Base):
+    __tablename__ = "emails"
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -84,9 +84,9 @@ class UserEmail(Base):
 
 Index(
     'email_index',
-    UserEmail.provider,
-    UserEmail.identity_id,
-    UserEmail.email,
+    Email.provider,
+    Email.identity_id,
+    Email.email,
     unique=True,
 )
 
@@ -100,7 +100,7 @@ class Identity(Base):
     user_id = Column(UUID, ForeignKey('users.id'))
 
     user = relationship('User', back_populates='identities')
-    emails = relationship('UserEmail', back_populates='identity')
+    emails = relationship('Email', back_populates='identity')
 
 
 Index('identity_index', Identity.provider, Identity.identity_id, unique=True)

--- a/quetz/migrations/versions/d212023a8e0b_add_useremail_table_for_email_addresses.py
+++ b/quetz/migrations/versions/d212023a8e0b_add_useremail_table_for_email_addresses.py
@@ -1,4 +1,4 @@
-"""add UserEmail table for email addresses
+"""add Email table for email addresses
 
 Revision ID: d212023a8e0b
 Revises: cddba8e6e639
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade():
     op.create_table(
-        'user_emails',
+        'emails',
         sa.Column('provider', sa.String(), nullable=False),
         sa.Column('identity_id', sa.String(), nullable=False),
         sa.Column('email', sa.String(), nullable=False),
@@ -35,14 +35,14 @@ def upgrade():
         sa.PrimaryKeyConstraint('provider', 'identity_id', 'email'),
         sa.UniqueConstraint('email'),
     )
-    with op.batch_alter_table('user_emails', schema=None) as batch_op:
+    with op.batch_alter_table('emails', schema=None) as batch_op:
         batch_op.create_index(
             'email_index', ['provider', 'identity_id', 'email'], unique=True
         )
 
 
 def downgrade():
-    with op.batch_alter_table('user_emails', schema=None) as batch_op:
+    with op.batch_alter_table('emails', schema=None) as batch_op:
         batch_op.drop_index('email_index')
 
-    op.drop_table('user_emails')
+    op.drop_table('emails')

--- a/quetz/migrations/versions/d212023a8e0b_add_useremail_table_for_email_addresses.py
+++ b/quetz/migrations/versions/d212023a8e0b_add_useremail_table_for_email_addresses.py
@@ -1,0 +1,48 @@
+"""add UserEmail table for email addresses
+
+Revision ID: d212023a8e0b
+Revises: cddba8e6e639
+Create Date: 2021-09-07 18:14:30.387156
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd212023a8e0b'
+down_revision = 'cddba8e6e639'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user_emails',
+        sa.Column('provider', sa.String(), nullable=False),
+        sa.Column('identity_id', sa.String(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('user_id', sa.LargeBinary(length=16), nullable=True),
+        sa.Column('verified', sa.Boolean(), nullable=True),
+        sa.Column('primary', sa.Boolean(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['provider', 'identity_id'],
+            ['identities.provider', 'identities.identity_id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'],
+            ['users.id'],
+        ),
+        sa.PrimaryKeyConstraint('provider', 'identity_id', 'email'),
+        sa.UniqueConstraint('email'),
+    )
+    with op.batch_alter_table('user_emails', schema=None) as batch_op:
+        batch_op.create_index(
+            'email_index', ['provider', 'identity_id', 'email'], unique=True
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user_emails', schema=None) as batch_op:
+        batch_op.drop_index('email_index')
+
+    op.drop_table('user_emails')

--- a/quetz/tests/authentification/test_auth_dao.py
+++ b/quetz/tests/authentification/test_auth_dao.py
@@ -1,7 +1,7 @@
 import pytest
 
 from quetz.authentication import auth_dao
-from quetz.db_models import UserEmail
+from quetz.db_models import Email
 from quetz.errors import ValidationError
 
 
@@ -100,8 +100,8 @@ def test_add_user_with_emails(dao, config):
 
     # Make sure that the email is properly deleted
     assert (
-        dao.db.query(UserEmail)
-        .filter(UserEmail.email == "w.vollprecht@abcdef.com")
+        dao.db.query(Email)
+        .filter(Email.email == "w.vollprecht@abcdef.com")
         .one_or_none()
         is None
     )

--- a/quetz/tests/authentification/test_auth_dao.py
+++ b/quetz/tests/authentification/test_auth_dao.py
@@ -1,6 +1,7 @@
 import pytest
 
 from quetz.authentication import auth_dao
+from quetz.db_models import UserEmail
 from quetz.errors import ValidationError
 
 
@@ -96,6 +97,14 @@ def test_add_user_with_emails(dao, config):
 
     with pytest.raises(KeyError):
         e = find_email(user.emails, "w.vollprecht@abcdef.com")
+
+    # Make sure that the email is properly deleted
+    assert (
+        dao.db.query(UserEmail)
+        .filter(UserEmail.email == "w.vollprecht@abcdef.com")
+        .one_or_none()
+        is None
+    )
 
 
 def test_add_user_with_same_email(dao, config):

--- a/quetz/tests/authentification/test_auth_dao.py
+++ b/quetz/tests/authentification/test_auth_dao.py
@@ -1,4 +1,14 @@
+import pytest
+
 from quetz.authentication import auth_dao
+from quetz.errors import ValidationError
+
+
+def find_email(emails, e):
+    for eo in emails:
+        if eo.email == e:
+            return eo
+    raise KeyError("Missing email from list")
 
 
 def test_get_user_by_identity_new_user(dao, config):
@@ -16,3 +26,122 @@ def test_get_user_by_identity_new_user(dao, config):
     assert user.username == 'bartosz'
     assert user.identities[0].provider == 'github'
     assert user.identities[0].identity_id == '4567'
+
+
+def test_add_user_with_emails(dao, config):
+    profile = {
+        "id": 1234,
+        "login": "wolfv",
+        "name": "wolfv",
+        "avatar_url": "url",
+        "emails": [
+            {"email": "w.vollprecht@abcdef.com", "verified": True, "primary": True},
+            {
+                "email": "wolf.vollprecht@lasersight.net",
+                "verified": False,
+                "primary": False,
+            },
+        ],
+    }
+    provider = "github"
+
+    user = auth_dao.get_user_by_identity(
+        dao, provider=provider, profile=profile, config=config
+    )
+
+    assert user.username == "wolfv"
+    assert len(user.emails) == 1
+    e = find_email(user.emails, "w.vollprecht@abcdef.com")
+    assert e.email == "w.vollprecht@abcdef.com"
+    assert e.verified is True
+    assert e.primary is True
+
+    profile["emails"][1]["verified"] = True
+
+    user = auth_dao.get_user_by_identity(
+        dao, provider=provider, profile=profile, config=config
+    )
+
+    e = find_email(user.emails, "wolf.vollprecht@lasersight.net")
+    assert e.email == "wolf.vollprecht@lasersight.net"
+
+    profile["emails"].append(
+        {
+            "email": "another.email@github.net",
+            "verified": True,
+            "primary": False,
+        }
+    )
+
+    user = auth_dao.get_user_by_identity(
+        dao, provider=provider, profile=profile, config=config
+    )
+
+    e = find_email(user.emails, "another.email@github.net")
+    assert e.email == "another.email@github.net"
+
+    profile["emails"] = profile["emails"][1:]
+    profile["emails"][0]["primary"] = True
+    profile["login"] = "franky"
+
+    user = auth_dao.get_user_by_identity(
+        dao, provider=provider, profile=profile, config=config
+    )
+
+    assert len(user.emails) == 2
+    # assert user.username == "franky"
+    e = find_email(user.emails, "wolf.vollprecht@lasersight.net")
+    assert e.email == "wolf.vollprecht@lasersight.net"
+    assert e.primary is True
+
+    with pytest.raises(KeyError):
+        e = find_email(user.emails, "w.vollprecht@abcdef.com")
+
+
+def test_add_user_with_same_email(dao, config):
+    profile = {
+        "id": 1234,
+        "login": "wolfv",
+        "name": "wolfv",
+        "avatar_url": "url",
+        "emails": [
+            {"email": "w.vollprecht@abcdef.com", "verified": True, "primary": True},
+            {
+                "email": "wolf.vollprecht@lasersight.net",
+                "verified": True,
+                "primary": False,
+            },
+        ],
+    }
+    provider = "github"
+
+    profile2 = {
+        "id": 1234,
+        "login": "gitlab_wolfv",
+        "name": "Wolf Vollprecht",
+        "avatar_url": "url",
+        "emails": [
+            {
+                "email": "wolf.vollprecht@lasersight.net",
+                "verified": True,
+                "primary": False,
+            },
+        ],
+    }
+    provider2 = "gitlab"
+
+    user = auth_dao.get_user_by_identity(
+        dao, provider=provider, profile=profile, config=config
+    )
+
+    assert user.username == "wolfv"
+    e = find_email(user.emails, "w.vollprecht@abcdef.com")
+    assert e.email == "w.vollprecht@abcdef.com"
+    assert len(user.emails) == 2
+    assert e.verified is True
+    assert e.primary is True
+
+    with pytest.raises(ValidationError):
+        user = auth_dao.get_user_by_identity(
+            dao, provider=provider2, profile=profile2, config=config
+        )

--- a/quetz/tests/test_dao.py
+++ b/quetz/tests/test_dao.py
@@ -398,6 +398,7 @@ def test_create_user_with_profile(dao: Dao, user_without_profile):
         identity_id="1",
         name="new user",
         avatar_url="http://avatar",
+        emails=None,
         role=None,
         exist_ok=True,
     )


### PR DESCRIPTION
This PR adds a `email` field to the User. For any kind of real-world deployment we will definitely need to collect email addresses. 

I am not sure if we should make this a opt-in feature or not ... it's "easy" to collect email adresses for Github / gitlab etc. providers, but for LDAP and others it would not be so simple.