### PR TITLE
clean up frontend.py and move lab-specific stuff to quetz-frontend extension

### DIFF
--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-
+import pkg_resources
 import jinja2
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse, HTMLResponse
@@ -11,7 +11,7 @@ from starlette.staticfiles import StaticFiles
 
 from quetz import authorization, rest_models
 from quetz.authentication import AuthenticatorRegistry
-from quetz.config import Config
+from quetz.config import Config, get_plugin_manager
 from quetz.dao import Dao
 from quetz.deps import get_dao, get_rules, get_session
 
@@ -19,7 +19,6 @@ config = Config()
 
 logger = logging.getLogger('quetz')
 
-mock_router = APIRouter()
 catchall_router = APIRouter()
 
 mock_settings_dict = None
@@ -27,66 +26,6 @@ frontend_dir = ""
 index_template = None
 config_data: dict
 
-
-@mock_router.get('/api/sessions', include_in_schema=False)
-def mock_sessions():
-    return []
-
-
-@mock_router.get('/api/kernels', include_in_schema=False)
-def mock_kernels():
-    return []
-
-
-@mock_router.get('/api/kernelspecs', include_in_schema=False)
-def mock_kernelspecs():
-    return []
-
-
-@mock_router.get('/api/settings', include_in_schema=False)
-def mock_settings():
-    return mock_settings_dict
-
-
-@mock_router.get('/quetz-themes/{resource:path}', include_in_schema=False)
-def get_theme(resource: str):
-    final_path = os.path.join(frontend_dir, resource)
-    logger.info(f"Getting file from {frontend_dir}")
-    logger.info(final_path)
-    if os.path.exists(final_path):
-        return FileResponse(path=final_path)
-    else:
-        raise HTTPException(status_code=404)
-
-
-def render_index(config):
-    global mock_settings_dict
-    global index_template
-
-    static_dir = config.general_frontend_dir
-
-    logger.info("Rendering index.html!")
-    static_dir = Path(static_dir)
-    if (static_dir / ".." / "templates").exists():
-        with open(static_dir / "index.html") as fi:
-            index_template = jinja2.Template(fi.read())
-
-        with open(static_dir / ".." / "templates" / "settings.json") as fi:
-            settings_template = json.load(fi)
-
-        with open(static_dir / ".." / "templates" / "default_settings.json") as fi:
-            default_settings = fi.read()
-
-        for setting in settings_template["settings"]:
-            if setting["id"] == '@jupyterlab/apputils-extension:themes':
-                setting["raw"] = default_settings
-
-        with open(os.path.join(static_dir, "index.html"), "w") as fo:
-            fo.write(index_template.render(page_config=config_data))
-
-        mock_settings_dict = settings_template
-        with open(static_dir / "settings.json", "w") as fo:
-            fo.write(json.dumps(settings_template))
 
 
 def _under_frontend_dir(path):
@@ -142,41 +81,34 @@ def get_rendered_index(config_data, profile, index_template):
 
 
 def register(app):
+    frontend_plugins = []
+    for entry_point in pkg_resources.iter_entry_points('quetz.frontend'):
+        frontend_plugins.append(entry_point)
+
+    if len(frontend_plugins) > 1:
+        logger.warning(f"Multiple frontend plugins found! {', '.join(frontend_plugins)}\nUsing last found.")
+
+    if frontend_plugins:
+        print("Register frontend hooks: ", frontend_plugins)
+        logger.info(f"Loading frontend plugin: {frontend_plugins[-1]}")
+        frontend_plugin = frontend_plugins[-1].load()
+        return frontend_plugin.register(app)
+
     # TODO fix, don't put under /api/
     # This is to help the jupyterlab-based frontend to not
     # have any 404 requests.
     global frontend_dir
     global config_data
 
-    auth_registry = AuthenticatorRegistry()
-    google_login_available = auth_registry.is_registered("google")
-    github_login_available = auth_registry.is_registered("github")
-    gitlab_login_available = auth_registry.is_registered("gitlab")
-
-    config_data = {
-        "appName": "Quetz – the fast conda package server!",
-        "baseUrl": "/jlabmock/",
-        "github_login_available": github_login_available,
-        "gitlab_login_available": gitlab_login_available,
-        "google_login_available": google_login_available,
-    }
 
     logger.info(f"Frontend config: {config_data}")
-
-    app.include_router(mock_router, prefix="/jlabmock")
 
     # TODO do not add this in the final env, use nginx to route
     #      to static files
     app.include_router(catchall_router)
+
     # mount frontend
-    if hasattr(config, 'general_frontend_dir') and config.general_frontend_dir:
-        render_index(config)
-        frontend_dir = config.general_frontend_dir
-        logger.info(f"Configured frontend found: {config.general_frontend_dir}")
-    elif os.path.isfile("../quetz_frontend/dist/index.html"):
-        logger.info("dev frontend found")
-        frontend_dir = "../quetz_frontend/dist"
-    elif os.path.isfile(f"{sys.prefix}/share/quetz/frontend/index.html"):
+    if os.path.isfile(f"{sys.prefix}/share/quetz/frontend/index.html"):
         logger.info("installed frontend found")
         frontend_dir = f"{sys.prefix}/share/quetz/frontend/"
     else:
@@ -184,6 +116,7 @@ def register(app):
         frontend_dir = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "basic_frontend"
         )
+
     app.mount(
         "/",
         StaticFiles(directory=frontend_dir, html=True),


### PR DESCRIPTION
We're moving the jupyter lab based frontend to a plugin that ships it's own backend helpers. 

This will also give additional freedom to other frontend implementers.

Here is the frontend repo: http://github.com/mamba-org/quetz-frontend

PS: @stevenryoung I am curious what frontend you were using so far? Would be happy to assist you in moving to the new one, or hearing your experiences.