### PR TITLE
Remove async from serve_path

### DIFF
--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1552,7 +1552,7 @@ async def stop_sync_donwload_counts():
 
 
 @app.get("/get/{channel_name}/{path:path}")
-async def serve_path(
+def serve_path(
     path,
     channel: db_models.Channel = Depends(get_channel_allow_proxy),
     accept_encoding: Optional[str] = Header(None),
@@ -1650,13 +1650,13 @@ async def serve_path(
 
 
 @app.get("/get/{channel_name}")
-async def serve_channel_index(
+def serve_channel_index(
     channel: db_models.Channel = Depends(get_channel_allow_proxy),
     accept_encoding: Optional[str] = Header(None),
     session=Depends(get_remote_session),
     dao: Dao = Depends(get_dao),
 ):
-    return await serve_path("index.html", channel, accept_encoding, session, dao)
+    return serve_path("index.html", channel, accept_encoding, session, dao)
 
 
 frontend.register(app)


### PR DESCRIPTION
As far as I can see, the serve_path function doesn't contain any async method.
When using blocking operation, the function shouldn't be defined as async.

See https://fastapi.tiangolo.com/advanced/custom-response/?h=stream#using-streamingresponse-with-file-like-objects

When trying to access the API at the same time as downloading files from quetz, I got very poor response time.
I think this is because serve_path was blocking the event loop.
With this change, I get much better results.