### PR TITLE
Add option to redirect static file download

### DIFF
--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
@@ -18,7 +18,7 @@ def get_conda_suggest(channel_name, subdir, db: Session = Depends(get_db)):
     map_filename = "{0}.{1}.map".format(channel_name, subdir)
     map_filepath = pkgstore.url(channel_name, f"{subdir}/{map_filename}")
     try:
-        if map_filepath.startswith("http"):
+        if pkgstore.support_redirect:
             return RedirectResponse(map_filepath)
         elif os.path.isfile(map_filepath):
             return FileResponse(

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -116,7 +116,7 @@ class Config:
         ConfigSection(
             "local_store",
             [
-                ConfigEntry("redirect_static_files", bool, default=False),
+                ConfigEntry("redirect_enabled", bool, default=False),
                 ConfigEntry("redirect_endpoint", str, default="/files"),
             ],
         ),
@@ -377,6 +377,7 @@ class Config:
             return pkgstores.LocalStore(
                 {
                     'channels_dir': 'channels',
+                    'redirect_enabled': self.local_store_redirect_enabled,
                     'redirect_endpoint': self.local_store_redirect_endpoint,
                 }
             )

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -114,6 +114,13 @@ class Config:
             [ConfigEntry("secret", str), ConfigEntry("https_only", bool, default=True)],
         ),
         ConfigSection(
+            "local_store",
+            [
+                ConfigEntry("redirect_static_files", bool, default=False),
+                ConfigEntry("redirect_endpoint", str, default="/files"),
+            ],
+        ),
+        ConfigSection(
             "s3",
             [
                 ConfigEntry("access_key", str, default=""),
@@ -192,13 +199,6 @@ class Config:
                 ConfigEntry("channel_quota", int, required=False),
             ],
             required=False,
-        ),
-        ConfigSection(
-            "download",
-            [
-                ConfigEntry("redirect_static_files", bool, default=False),
-                ConfigEntry("redirect_endpoint", str, default="/files"),
-            ],
         ),
     ]
     _config_dirs = [_site_dir, _user_dir]
@@ -377,7 +377,7 @@ class Config:
             return pkgstores.LocalStore(
                 {
                     'channels_dir': 'channels',
-                    'redirect_endpoint': self.download_redirect_endpoint,
+                    'redirect_endpoint': self.local_store_redirect_endpoint,
                 }
             )
 

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -193,6 +193,13 @@ class Config:
             ],
             required=False,
         ),
+        ConfigSection(
+            "download",
+            [
+                ConfigEntry("redirect_static_files", bool, default=False),
+                ConfigEntry("redirect_endpoint", str, default="/files"),
+            ],
+        ),
     ]
     _config_dirs = [_site_dir, _user_dir]
     _config_files = [os.path.join(d, _filename) for d in _config_dirs]
@@ -367,7 +374,12 @@ class Config:
                 }
             )
         else:
-            return pkgstores.LocalStore({'channels_dir': 'channels'})
+            return pkgstores.LocalStore(
+                {
+                    'channels_dir': 'channels',
+                    'redirect_endpoint': self.download_redirect_endpoint,
+                }
+            )
 
     def configured_section(self, section: str) -> bool:
         """Return if a given section has been configured.

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1609,7 +1609,7 @@ async def serve_path(
         path += "index.html"
     package_content_iter = None
 
-    if config.download_redirect_static_files and hasattr(pkgstore, "redirect_url"):
+    if config.local_store_redirect_static_files and hasattr(pkgstore, "redirect_url"):
         url = pkgstore.redirect_url(channel.name, path)  # type: ignore
         return RedirectResponse(url=url)
 

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -85,6 +85,7 @@ class LocalStore(PackageStore):
     def __init__(self, config):
         self.fs: fsspec.AbstractFileSystem = fsspec.filesystem("file")
         self.channels_dir = config['channels_dir']
+        self.redirect_endpoint = config['redirect_endpoint']
 
     @contextmanager
     def _atomic_open(self, channel: str, destination: StrPath, mode="wb") -> IO:
@@ -145,6 +146,9 @@ class LocalStore(PackageStore):
     def url(self, channel: str, src: str, expires=None):
         filepath = path.abspath(path.join(self.channels_dir, channel, src))
         return filepath
+
+    def redirect_url(self, channel: str, src: str):
+        return path.join(self.redirect_endpoint, self.channels_dir, channel, src)
 
     def get_filemetadata(self, channel: str, src: str):
         filepath = path.abspath(path.join(self.channels_dir, channel, src))

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -169,7 +169,7 @@ def get_from_cache_or_download(
         data_stream = remote_file.file
         cache.dump(target, data_stream)
 
-    if config.local_store_redirect_static_files:
+    if config.local_store_redirect_enabled:
         return RedirectResponse(
             url=os.path.join(config.local_store_redirect_endpoint, cache[target])
         )

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -169,9 +169,9 @@ def get_from_cache_or_download(
         data_stream = remote_file.file
         cache.dump(target, data_stream)
 
-    if config.download_redirect_static_files:
+    if config.local_store_redirect_static_files:
         return RedirectResponse(
-            url=os.path.join(config.download_redirect_endpoint, cache[target])
+            url=os.path.join(config.local_store_redirect_endpoint, cache[target])
         )
     return FileResponse(cache[target])
 

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -604,7 +604,7 @@ def test_download_remote_file(client, owner, dummy_repo):
     assert dummy_repo == [("http://host/test_file_2.txt")]
 
 
-def test_always_download_repodata(client, owner, dummy_repo):
+def test_proxy_repodata_cached(client, owner, dummy_repo):
     """Test downloading from cache."""
     response = client.get("/api/dummylogin/bartosz")
     assert response.status_code == 200
@@ -628,8 +628,9 @@ def test_always_download_repodata(client, owner, dummy_repo):
     assert response.status_code == 200
     assert response.content == b"Hello world!"
 
+    # repodata.json was cached locally and downloaded from the
+    # the remote only once
     assert dummy_repo == [
-        ("http://host/repodata.json"),
         ("http://host/repodata.json"),
     ]
 

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -28,12 +28,19 @@ azure_config = {
 test_dir = os.path.dirname(__file__)
 
 
-def test_local_store():
+@pytest.mark.parametrize("redirect_enabled", [False, True])
+def test_local_store(redirect_enabled):
 
     temp_dir = os.path.join(test_dir, "test_pkg_store_" + str(int(time.time())))
     os.makedirs(temp_dir, exist_ok=False)
 
-    pkg_store = LocalStore({"channels_dir": temp_dir, "redirect_endpoint": "/files"})
+    pkg_store = LocalStore(
+        {
+            "channels_dir": temp_dir,
+            "redirect_enabled": redirect_enabled,
+            "redirect_endpoint": "/files",
+        }
+    )
 
     pkg_store.add_file("content", "my-channel", "test.txt")
     pkg_store.add_file("content".encode('ascii'), "my-channel", "test_2.txt")
@@ -74,7 +81,13 @@ def local_store():
     temp_dir = os.path.join(test_dir, "test_pkg_store_" + str(int(time.time())))
     os.makedirs(temp_dir, exist_ok=False)
 
-    pkg_store = LocalStore({"channels_dir": temp_dir, "redirect_endpoint": "/files"})
+    pkg_store = LocalStore(
+        {
+            "channels_dir": temp_dir,
+            "redirect_enabled": False,
+            "redirect_endpoint": "/files",
+        }
+    )
 
     yield pkg_store
 
@@ -193,10 +206,18 @@ def test_move_file(any_store, channel, channel_name):
     assert_files(['test_2.txt'])
 
 
+@pytest.mark.parametrize("redirect_enabled", [False, True])
 @pytest.mark.parametrize("redirect_endpoint", ["/files", "/static"])
-def test_local_store_redirect_url(redirect_endpoint):
+def test_local_store_url(redirect_enabled, redirect_endpoint):
     local_store = LocalStore(
-        {"channels_dir": "channels", "redirect_endpoint": redirect_endpoint}
+        {
+            "channels_dir": "channels",
+            "redirect_enabled": redirect_enabled,
+            "redirect_endpoint": redirect_endpoint,
+        }
     )
-    url = local_store.redirect_url("mychannel", "linux-64/foo.tar.bz2")
-    assert url == f"{redirect_endpoint}/channels/mychannel/linux-64/foo.tar.bz2"
+    url = local_store.url("mychannel", "linux-64/foo.tar.bz2")
+    if redirect_enabled:
+        assert url == f"{redirect_endpoint}/channels/mychannel/linux-64/foo.tar.bz2"
+    else:
+        assert url == os.path.abspath("channels/mychannel/linux-64/foo.tar.bz2")

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -33,7 +33,7 @@ def test_local_store():
     temp_dir = os.path.join(test_dir, "test_pkg_store_" + str(int(time.time())))
     os.makedirs(temp_dir, exist_ok=False)
 
-    pkg_store = LocalStore({'channels_dir': temp_dir})
+    pkg_store = LocalStore({"channels_dir": temp_dir, "redirect_endpoint": "/files"})
 
     pkg_store.add_file("content", "my-channel", "test.txt")
     pkg_store.add_file("content".encode('ascii'), "my-channel", "test_2.txt")
@@ -74,7 +74,7 @@ def local_store():
     temp_dir = os.path.join(test_dir, "test_pkg_store_" + str(int(time.time())))
     os.makedirs(temp_dir, exist_ok=False)
 
-    pkg_store = LocalStore({'channels_dir': temp_dir})
+    pkg_store = LocalStore({"channels_dir": temp_dir, "redirect_endpoint": "/files"})
 
     yield pkg_store
 
@@ -191,3 +191,12 @@ def test_move_file(any_store, channel, channel_name):
     pkg_store.move_file(channel_name, "test.txt", "test_2.txt")
 
     assert_files(['test_2.txt'])
+
+
+@pytest.mark.parametrize("redirect_endpoint", ["/files", "/static"])
+def test_local_store_redirect_url(redirect_endpoint):
+    local_store = LocalStore(
+        {"channels_dir": "channels", "redirect_endpoint": redirect_endpoint}
+    )
+    url = local_store.redirect_url("mychannel", "linux-64/foo.tar.bz2")
+    assert url == f"{redirect_endpoint}/channels/mychannel/linux-64/foo.tar.bz2"


### PR DESCRIPTION
This is an attempt to improve performances when using LocalStore by letting nginx serve static files.

If `redirect_static_files` is set to `true`, quetz will return a redirect for:
- files in the cache (cached packages from proxy channels)
- files from local channels when using LocalStore

In this case, Nginx (or something else) is expected to take care of this redirect.

I tested by deploying Nginx with something like that:

```
    upstream quetz {
      server 127.0.0.1:8000;
    }

    server {
        listen      8080;
        add_header  Cache-Control $control;

        server_name  localhost;

        location / {
          proxy_set_header Host $http_host;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto $scheme;
          proxy_set_header Upgrade $http_upgrade;
          proxy_set_header Connection $connection_upgrade;
          proxy_redirect off;
          proxy_buffering off;
          proxy_pass http://quetz;
        }

        location /files/cache/ {
          # path for cache files
          alias /quetz-deployment/cache/;
        }

        location /files/channels/ {
          # path for channels
          alias /quetz-deployment/channels/;
        }
    }
```

By default, the new option is set to False and nothing should change.

There are probably things to discuss. I'm also not sure what should be done for other package stores.
