### PR TITLE
Add documentation about Nginx for static file redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   web:
     image: quetz_dev_image
+    container_name: quetz-web
     ports:
       - "8000:8000"
     build: 
@@ -54,6 +55,17 @@ services:
     command: jupyterhub --debug
     ports:
       - 8001:8000
+  nginx:
+    image: nginx:stable
+    container_name: quetz-nginx
+    entrypoint: ["nginx", "-g", "daemon off;"]
+    ports:
+      - "8080:8080"
+    depends_on:
+      - web
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf
+      - quetz_deployment:/quetz-deployment
 
 volumes:
   quetz_deployment:

--- a/docker/docker_config.toml
+++ b/docker/docker_config.toml
@@ -25,3 +25,6 @@ client_secret = "super-secret"
 access_token_url = "http://jupyterhub:8000/hub/api/oauth2/token"
 authorize_url = "http://localhost:8001/hub/api/oauth2/authorize"
 api_base_url = "http://jupyterhub:8000/hub/api/"
+
+[local_store]
+redirect_enabled = true

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,70 @@
+worker_processes  1;
+# Nginx shall have read access to files created by Quetz
+# Same user should be used to run both applications
+# Using root for development even if it's not recommended
+user    root;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    map $cache $control {
+        1       "max-age=1200";
+    }
+    map $uri $cache {
+        ~*\.(json)$    1;
+    }
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_types  application/json;
+
+    client_max_body_size 100m;
+
+    upstream quetz {
+      server quetz-web:8000;
+    }
+
+    server {
+        listen      8080;
+        add_header  Cache-Control $control;
+
+        server_name  localhost;
+
+        location / {
+          proxy_set_header Host $http_host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection $connection_upgrade;
+          proxy_redirect off;
+          proxy_buffering off;
+          proxy_pass http://quetz;
+        }
+
+        location /files/channels/ {
+          # path for channels
+          alias /quetz-deployment/channels/;
+        }
+    }
+
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      '' close;
+    }
+}

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -127,6 +127,25 @@ Quetz can store package in object cloud storage compatible with S3 interface. To
 :bucket_prefix:
 :bucket_suffix: channel directories on S3 are created with the following semantics: ``{bucket_prefix}{channel_name}{bucket_suffix}``
 
+``local_store`` section
+^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, Quetz stores packages on the local filesystem and all files
+are streamed by the application. To improve performances, it is recommended to deploy
+Nginx in front of Quetz to serve those files.
+
+This can be achieved by setting ``redirect_enabled`` to ``true``.
+Requests for conda packages and json files will be redirected to a specific endpoint (``redirect_endpoint``)
+which shall be configured in Nginx. See :ref:`nginx_config` for more information.
+
+
+.. code::
+
+    [local_store]
+    redirect_enabled = true
+    redirect_endpoint = "/files"
+
+
 .. _worker_config:
 
 ``worker`` section

--- a/docs/source/deploying/index.rst
+++ b/docs/source/deploying/index.rst
@@ -14,4 +14,4 @@ infrastructure.
    migrations
    frontend
    workers
-
+   nginx

--- a/docs/source/deploying/nginx.rst
+++ b/docs/source/deploying/nginx.rst
@@ -1,0 +1,137 @@
+.. _nginx_config:
+
+Nginx
+=====
+
+Nginx can be deployed in front of Quetz to improve performances when using local storage.
+
+.. note::
+
+   When using ``S3`` or ``Azure`` as file storage, packages are served directly from the cloud.
+   Using Nginx won't make much difference in that case.
+
+
+Configuration
+-------------
+
+Here is an example configuration to use Nginx in front of Quetz:
+
+.. code::
+
+	worker_processes  1;
+	pid        /tmp/nginx.pid;
+
+	events {
+	    worker_connections  1024;
+	}
+
+	http {
+	    map $cache $control {
+		1       "max-age=1200";
+	    }
+	    map $uri $cache {
+		~*\.(json)$    1;
+	    }
+	    proxy_temp_path /tmp/proxy_temp;
+	    client_body_temp_path /tmp/client_temp;
+	    fastcgi_temp_path /tmp/fastcgi_temp;
+	    uwsgi_temp_path /tmp/uwsgi_temp;
+	    scgi_temp_path /tmp/scgi_temp;
+
+	    include       mime.types;
+	    default_type  application/octet-stream;
+
+	    sendfile        on;
+	    tcp_nopush      on;
+	    tcp_nodelay     on;
+
+	    keepalive_timeout  65;
+
+	    gzip  on;
+	    gzip_types  application/json;
+
+	    client_max_body_size 100m;
+
+	    upstream quetz {
+	      server 127.0.0.1:8000;
+	    }
+
+	    server {
+		listen      8080;
+		add_header  Cache-Control $control;
+
+		server_name  localhost;
+
+		location / {
+		  proxy_set_header Host $http_host;
+		  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		  proxy_set_header X-Forwarded-Proto $scheme;
+		  proxy_set_header Upgrade $http_upgrade;
+		  proxy_set_header Connection $connection_upgrade;
+		  proxy_redirect off;
+		  proxy_buffering off;
+		  proxy_pass http://quetz;
+		}
+
+		location /files/channels/ {
+		  # path for channels
+		  alias /quetz-deployment/channels/;
+		}
+	    }
+
+	    map $http_upgrade $connection_upgrade {
+	      default upgrade;
+	      '' close;
+	    }
+	}
+
+Requests for files under ``/files/channels/`` will be served by Nginx.
+All other requests are passed to the Quetz application, which is running locally on port 8000
+in this example.
+
+.. warning::
+
+   This configuration disables any authentication to access files under the ``channels``
+   directory. This isn't an issue if you only have public channels.
+   Authentication for private channels hasn't been implemented yet.
+
+client_max_body_size
+^^^^^^^^^^^^^^^^^^^^
+
+The default maximum allowed size of the client request body is 1MB.
+Don't forget to increase it to upload bigger packages.
+Request Entity Too Large (413) will be returned otherwise.
+
+.. code::
+
+   client_max_body_size 100m;
+
+Compress json files
+^^^^^^^^^^^^^^^^^^^
+
+Nginx can be configured to automatically compress json files using::
+
+    gzip  on;
+    gzip_types  application/json;
+
+Add cache-control header for json files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It's possible to add cache-control header for json files.
+For the ``repodata.json`` file to be cached by conda, ``max-age`` can be added
+to the header by Nginx when serving json files.
+
+Under the ``http`` section::
+
+   map $cache $control {
+     1       "max-age=1200";
+   }
+   map $uri $cache {
+     ~*\.(json)$    1;
+   }
+
+Under the ``server`` section::
+
+   add_header  Cache-Control $control;
+
+Note that the same value will be used for all channels.

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1598,7 +1598,9 @@ def serve_path(
         if channel_proxylist and package_name and package_name in channel_proxylist:
             return RedirectResponse(f"{channel.mirror_channel_url}/{path}")
 
-    if is_package_request and pkgstore.support_redirect:
+    if (
+        is_package_request or pkgstore.kind == "LocalStore"
+    ) and pkgstore.support_redirect:
         return RedirectResponse(pkgstore.url(channel.name, path))
 
     def iter_chunks(fid):

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -38,6 +38,10 @@ class PackageStore(abc.ABC):
         pass
 
     @property
+    def kind(self):
+        return type(self).__name__
+
+    @property
     @abc.abstractmethod
     def support_redirect(self) -> bool:
         pass


### PR DESCRIPTION
- Serve all files with Nginx when using LocalStore (including `repodata.json`)
- Add nginx config to docker-compose for local testing
- Add documentation about nginx configuration

I think serving json files with Nginx when it is already configured for channels makes sense as it can compress json files and add max-age to the cache-control header (as shown in the example and documentation). The only drawback I see is that the `max-age` will be the same for all channels. It has to be hard-coded in Nginx configuration and can't be set to the channel ttl.

This is only enabled for the LocalStore as Nginx needs to be configured. Maybe it should be enabled via a different option so it can be used when using another package store?