### PR TITLE
Prevent remote files to be downloaded several times in parallel

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -9,9 +9,9 @@ import os
 import os.path as path
 import shutil
 import tempfile
-from threading import Lock
 from contextlib import contextmanager
 from os import PathLike
+from threading import Lock
 from typing import IO, BinaryIO, List, NoReturn, Tuple, Union
 
 import fsspec
@@ -34,7 +34,6 @@ logger = logging.getLogger("quetz")
 
 
 class PackageStore(abc.ABC):
-
     def __init__(self):
         self._download_locks = {}
 
@@ -110,7 +109,6 @@ class PackageStore(abc.ABC):
 
 
 class LocalStore(PackageStore):
-
     def __init__(self, config):
         self.fs: fsspec.AbstractFileSystem = fsspec.filesystem("file")
         self.channels_dir = config['channels_dir']

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -9,6 +9,7 @@ import os
 import os.path as path
 import shutil
 import tempfile
+from threading import Lock
 from contextlib import contextmanager
 from os import PathLike
 from typing import IO, BinaryIO, List, NoReturn, Tuple, Union
@@ -33,9 +34,19 @@ logger = logging.getLogger("quetz")
 
 
 class PackageStore(abc.ABC):
-    @abc.abstractmethod
+
     def __init__(self):
-        pass
+        self._download_locks = {}
+
+    def get_download_lock(self, channel: str, destination: str):
+        return self._download_locks.get((channel, destination))
+
+    def create_download_lock(self, channel: str, destination: str):
+        lock = self._download_locks[(channel, destination)] = Lock()
+        return lock
+
+    def delete_download_lock(self, channel: str, destination: str):
+        del self._download_locks[(channel, destination)]
 
     @property
     def kind(self):
@@ -99,11 +110,13 @@ class PackageStore(abc.ABC):
 
 
 class LocalStore(PackageStore):
+
     def __init__(self, config):
         self.fs: fsspec.AbstractFileSystem = fsspec.filesystem("file")
         self.channels_dir = config['channels_dir']
         self.redirect_enabled = config['redirect_enabled']
         self.redirect_endpoint = config['redirect_endpoint']
+        super().__init__()
 
     @property
     def support_redirect(self):
@@ -243,6 +256,7 @@ class S3Store(PackageStore):
 
         self.bucket_prefix = config['bucket_prefix']
         self.bucket_suffix = config['bucket_suffix']
+        super().__init__()
 
     @property
     def support_redirect(self):
@@ -382,6 +396,7 @@ class AzureBlobStore(PackageStore):
 
         self.container_prefix = config['container_prefix']
         self.container_suffix = config['container_suffix']
+        super().__init__()
 
     @property
     def support_redirect(self):

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -108,13 +108,16 @@ def download_remote_file(
 ):
     """Download a file from a remote repository to a package store"""
 
+    # Check if a download is already underway for this file
     lock = pkgstore.get_download_lock(channel, path)
     if lock:
+        # Wait for the download to complete
         lock.acquire()
+        # Release the lock so that any other clients can also finish
         lock.release()
         return
-    lock = pkgstore.create_download_lock(channel, path)
-    with lock:
+    # Acquire a lock to prevent multiple concurrent downloads of the same file
+    with pkgstore.create_download_lock(channel, path):
         logger.debug(f"Downloading {path} from {channel} to pkgstore")
         remote_file = repository.open(path)
         data_stream = remote_file.file


### PR DESCRIPTION
If several clients try to download the same file from a proxy channel in parallel, that file is currently downloaded several times.
This is quite inefficient and adds extra load on the remote repo.

To prevent this and ensure the file is only downloaded once, we added a lock. Other clients will wait while the file is downloaded by the first request.