### PR TITLE
Make `assert_user` check that user exists in db

### DIFF
--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -62,7 +62,7 @@ class Rules:
     def assert_user(self) -> bytes:
         user_id = self.get_user()
 
-        if not user_id:
+        if not user_id or not self.db.query(User).filter(User.id == user_id).count():
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Not logged in",


### PR DESCRIPTION
Description
---

The session may contain a `user_id` that is not in the database anymore.
Make `assert_user` catch this case

Related to https://github.com/mamba-org/quetz/issues/429