### PR TITLE
add debug info and use bytes for user_id

### DIFF
--- a/quetz/tasks/reindexing.py
+++ b/quetz/tasks/reindexing.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import uuid
 
 from sqlalchemy.exc import IntegrityError
 
@@ -21,27 +22,31 @@ def handle_file(
     dao,
     user_id,
 ):
-
+    user_id=uuid.UUID(user_id).bytes
     logger.debug(f"adding file '{filename}' to channel '{channel_name}'")
     condainfo = CondaInfo(file_buffer, filename)
-
     package_name = condainfo.info["name"]
+
+    logger.debug(f"adding {filename} as {channel_name}/{package_name} ")
 
     package = dao.get_package(channel_name, package_name)
 
     if not package:
+        logger.debug(f"creating new package {channel_name}/{package_name} with user {user_id} and role {authorization.OWNER}")
+
         dao.create_package(
             channel_name,
-            rest_models.Package(
+            new_package=rest_models.Package(
                 name=package_name,
                 summary=condainfo.about.get("summary", "n/a"),
                 description=condainfo.about.get("description", "n/a"),
             ),
-            user_id,
-            authorization.OWNER,
+            user_id=user_id,
+            role=authorization.OWNER,
         )
 
     # Update channeldata info
+    logger.debug(f"update package {channel_name}/{package_name}")
     dao.update_package_channeldata(channel_name, package_name, condainfo.channeldata)
 
     filename = os.path.split(filename)[-1]
@@ -75,6 +80,8 @@ def reindex_packages_from_store(
     user_id: bytes,
 ):
     """Reindex packages from files in the package store"""
+
+    logger.debug(f"reindex packages from {channel_name}")
 
     db = dao.db
 


### PR DESCRIPTION
Fixes the "reindex_packages_from_store:can't escape str to binary" error when trying to reindex an already existing S3 bucket.