### PR TITLE
Compatibility with `alembic` 1.7

### DIFF
--- a/quetz/frontend.py
+++ b/quetz/frontend.py
@@ -2,9 +2,9 @@ import logging
 import os
 import sys
 
-import pkg_resources
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
+from importlib_metadata import entry_points
 
 from quetz import authorization
 from quetz.config import Config
@@ -66,7 +66,7 @@ def static(
 
 def register(app):
     frontend_plugins = []
-    for entry_point in pkg_resources.iter_entry_points('quetz.frontend'):
+    for entry_point in entry_points().select(group='quetz.frontend'):
         frontend_plugins.append(entry_point)
 
     if len(frontend_plugins) > 1:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -15,7 +15,6 @@ from email.utils import formatdate
 from tempfile import SpooledTemporaryFile
 from typing import List, Optional, Tuple, Type
 
-import pkg_resources
 import pydantic
 import requests
 from fastapi import (
@@ -34,6 +33,7 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse, StreamingResponse
+from importlib_metadata import entry_points
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.concurrency import run_in_threadpool
@@ -166,7 +166,7 @@ builtin_authenticators: List[Type[BaseAuthenticator]] = [
 ]
 
 plugin_authenticators: List[Type[BaseAuthenticator]] = [
-    ep.load() for ep in pkg_resources.iter_entry_points('quetz.authenticator')
+    ep.load() for ep in entry_points().select(group='quetz.authenticator')
 ]
 
 


### PR DESCRIPTION
Description
---

fix tests using `alembic` 1.7
use `importlib` to load `entry_points`
remove use of `pkg_resources` to be consistent with `alembic` internal implementation
rename `dummy_plugin` fixture to `dummy_job_plugin` to be more explicit
rename `entry_points` fixture to `dummy_migration_plugin`
refactor `dummy_migration_plugin` to mock a package and its `entry_points`