### PR TITLE
make package_queue_size configurabe

### DIFF
--- a/quetz/config.py
+++ b/quetz/config.py
@@ -71,6 +71,7 @@ class Config:
             "general",
             [
                 ConfigEntry("package_unpack_threads", int, 1),
+                ConfigEntry("package_queue_size", int, 1),
                 ConfigEntry("frontend_dir", str, default=""),
             ],
         ),


### PR DESCRIPTION
This PR imports all versions of a package at the same time (instead of first importing packages version sorted by architecture) and adds an option package_queue_size to make it configurable how many packages will be imported before a new repodata.json file is generated.