### PR TITLE
feat: optionally redirect http to https

### DIFF
--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -76,6 +76,10 @@ Quetz can also create a channel for a newly connected user:
 
    Users with role ``None`` will not be able to create channels. However, they will be able to see all public channels and can be given permissions to private channels/packages by their owners/maintainers. You can also set ``create_default_channel`` option to automatically create a channel for the user, where they will have owner permissions.
 
+``general`` section
+^^^^^^^^^^^^^^^^^^^
+
+:redirect_http_to_https: Enforces that all incoming requests must be `https`. Any incoming requests to `http` will be redirected to the secure scheme instead. Defaults to `false`.
 
 ``session`` section
 ^^^^^^^^^^^^^^^^^^^

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -72,6 +72,7 @@ class Config:
             [
                 ConfigEntry("package_unpack_threads", int, 1),
                 ConfigEntry("frontend_dir", str, default=""),
+                ConfigEntry("redirect_http_to_https", bool, False),
             ],
         ),
         ConfigSection(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -38,6 +38,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.concurrency import run_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from tenacity import (
     after_log,
@@ -102,6 +103,10 @@ app.add_middleware(
     secret_key=config.session_secret,
     https_only=config.session_https_only,
 )
+
+if config.general_redirect_http_to_https:
+    logger.info("Configuring http to https redirect ")
+    app.add_middleware(HTTPSRedirectMiddleware)
 
 metrics.init(app)
 


### PR DESCRIPTION
Implementation of #445 . This PR adds the configurable ability for the quetz server to redirect all traffic to a secure endpoint.