### PR TITLE
update dependencies and re-enable repo.mamba.pm 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: quetz
 channels:
-  - conda-forge
+  - https://repo.mamba.pm/conda-forge
 dependencies:
   - python>=3.7
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -39,3 +39,4 @@ dependencies:
   - pamela
   - typing_extensions
   - adlfs
+  - importlib_metadata


### PR DESCRIPTION
This PR updates the quetz dependencies and re-enables package installation from repo.mamba.pm 