### PR TITLE
fix: gcs bucket exists

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -595,10 +595,10 @@ class GoogleCloudStorageStore(PackageStore):
             The name of the container to create on azure blob
         """
         with self._get_fs() as fs:
-            try:
-                fs.mkdir(self._bucket_map(name))
-            except FileExistsError:
-                pass
+            bucket_name = self._bucket_map(name)
+            if f"{bucket_name}/" not in fs.buckets:
+                fs.mkdir(bucket_name)
+                fs.invalidate_cache()
 
     def remove_channel(self, name):
         channel_path = self._bucket_map(name)

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -248,3 +248,8 @@ def test_local_store_url(redirect_enabled, redirect_endpoint):
         assert url == f"{redirect_endpoint}/channels/mychannel/linux-64/foo.tar.bz2"
     else:
         assert url == os.path.abspath("channels/mychannel/linux-64/foo.tar.bz2")
+
+
+def test_create_channel_multiple_times(any_store, channel_name):
+    any_store.create_channel(channel_name)
+    any_store.create_channel(channel_name)


### PR DESCRIPTION
If a bucket already exists `mkdir` in gscfs raises an HTTPError: "You already own this bucket.Please select another name., 409". I modified the behavior of `create_channel` to check if the bucket exists before creating it. This will usually result in the same number of API calls since most of the time the bucket will exist.