### PR TITLE
bump: httpx to 1.20.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - typer
   - authlib
   - psycopg2
-  - httpx=0.16.0
+  - httpx=0.20.0
   - sqlalchemy<1.4.0
   - sqlalchemy-utils
   - sqlite

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
   authlib
   alembic
   psycopg2
-  httpx~=0.16.0
+  httpx~=0.20.0
   sqlalchemy<1.4.0
   sqlalchemy-utils
   python-multipart


### PR DESCRIPTION
Bumps `httpx` to the latest version (1.20.0) to fix installation issues.  Running quetz with the old version (1.16.0) resulted in:

```
ImportError: cannot import name 'USE_CLIENT_DEFAULT' from 'httpx' (/home/runner/micromamba/envs/quetz/lib/python3.8/site-packages/httpx/__init__.py)
```

because [authlib merged a "fix" that enables it to work with `httpx >=1.18.2`](https://github.com/lepture/authlib/pull/393) but it breaks compatibility with older versions of httpx. Simply updating fixes the issue and since I couldn't find out why this was limited to 1.16.0 it seems like a valid solution.