### PR TITLE
feat: enable redirect with google cloud storage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - alembic
   - zchunk
   - s3fs
-  - gcsfs
+  - gcsfs >=2021.10.1
   - sphinx
   - sphinx-book-theme
   - tenacity

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -572,7 +572,7 @@ class GoogleCloudStorageStore(PackageStore):
     def support_redirect(self):
         # `gcsfs` currently doesnt support signing yet. Once this is implemented we
         # can enable this again.
-        return False
+        return True
 
     @contextlib.contextmanager
     def _get_fs(self):
@@ -667,10 +667,16 @@ class GoogleCloudStorageStore(PackageStore):
             ]
 
     def url(self, channel: str, src: str, expires=3600):
-        raise NotImplementedError("gcsfs doesnt support signing yet.")
-        # # expires is in seconds, so the default is 60 minutes!
-        # with self._get_fs() as fs:
-        #     return fs.sign(path.join(self._bucket_map(channel), src), expires)
+        # expires is in seconds, so the default is 60 minutes!
+        with self._get_fs() as fs:
+            expiration_timestamp = (
+                int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
+                + expires
+            )
+            redirect_url = fs.sign(
+                path.join(self._bucket_map(channel), src), expiration_timestamp
+            )
+            return redirect_url
 
     def get_filemetadata(self, channel: str, src: str):
         with self._get_fs() as fs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
   jinja2
   itsdangerous
   s3fs
-  gcsfs
+  gcsfs >=2021.10.1
   tenacity
   xattr
   aiofiles


### PR DESCRIPTION
With `gcsfs >=2021.10.1` we can now [sign Google Cloud Storage URLs](https://github.com/dask/gcsfs/pull/411). This MR adds redirection to google cloud storage for file downloads.

Note that this MR also contains the changes of #466 to ensure that CI passes. When #466 is merged I will rebase on that.