### PR TITLE
Fix bad package references

### DIFF
--- a/plugins/quetz_mamba_solve/README.md
+++ b/plugins/quetz_mamba_solve/README.md
@@ -2,12 +2,18 @@
 
 This is a plugin to use with the [quetz](https://github.com/mamba-org/quetz) package server.
 
-It takes `a list of channels`, a `subdir` and a `spec` as input and generates a specification file (similar to what `conda list --explicit` would produce). The contents of this file can be used to create an identical environment on a machine with the same platform. This can be done using the command `conda create --name myenv --file spec-file.txt` where `spec-file.txt` is the file containing the response from this API endpoint.
+It takes `a list of channels`, a `subdir` (also known as `platform`) and a `spec` as input and generates a specification file (similar to what `conda list --explicit` would produce). The contents of this file can be used to create an identical environment on a machine with the same platform. This can be done using the command `conda create --name myenv --file spec-file.txt` where `spec-file.txt` is the file containing the response from this API endpoint.
 
 ## Installing
 
-To install use:
+Make sure that both quetz and mamba are installed in the current environment. (It doesn't suffice to have the mamba executable installed in the base environment; the API must be available from Python.)
 
+```bash
+mamba install mamba
 ```
+
+To install this plugin:
+
+```bash
 pip install .
 ```

--- a/plugins/quetz_mamba_solve/requirements.txt
+++ b/plugins/quetz_mamba_solve/requirements.txt
@@ -1,2 +1,1 @@
-mamba
 conda-build >=3.20

--- a/plugins/quetz_mamba_solve/setup.py
+++ b/plugins/quetz_mamba_solve/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="quetz-mamba_solve",
-    install_requires=["quetz", "conda-build>=3.20", "mamba"],
+    install_requires=["conda-build>=3.20"],
     entry_points={"quetz": ["quetz-mamba_solve = quetz_mamba_solve.main"]},
     packages=["quetz_mamba_solve"],
 )


### PR DESCRIPTION
Both mamba and quetz from PyPI are unrelated!

* [mamba: the definitive test runner for Python](https://pypi.org/project/mamba/)
* [quetz: A Python library for compositional programming.](https://pypi.org/project/quetz/)