### PR TITLE
Fix compatibility with SQLAlchemy 1.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - authlib
   - psycopg2
   - httpx=0.20.0
-  - sqlalchemy<1.4.0
+  - sqlalchemy
   - sqlalchemy-utils
   - sqlite
   - python-multipart

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -106,6 +106,7 @@ class Upsert(Insert):
         self._returning = None
         self.table = table
         self.incr = incr
+        self._inline = False
 
 
 @compiles(Upsert, 'postgresql')

--- a/quetz/jobs/models.py
+++ b/quetz/jobs/models.py
@@ -41,7 +41,7 @@ class Job(Base):
     id = sa.Column(sa.Integer, primary_key=True)
     created = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
     updated = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
-    manifest = sa.Column(sa.Binary(), nullable=False)
+    manifest = sa.Column(sa.LargeBinary(), nullable=False)
     owner_id = sa.Column(
         UUID, sa.ForeignKey("users.id", ondelete="cascade"), nullable=True
     )

--- a/quetz/migrations/versions/794249a0b1bd_adding_jobs_tables.py
+++ b/quetz/migrations/versions/794249a0b1bd_adding_jobs_tables.py
@@ -22,7 +22,7 @@ def upgrade():
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created', sa.DateTime(), nullable=False),
         sa.Column('updated', sa.DateTime(), nullable=False),
-        sa.Column('manifest', sa.Binary(), nullable=False),
+        sa.Column('manifest', sa.LargeBinary(), nullable=False),
         sa.Column('owner_id', sa.LargeBinary(length=16), nullable=True),
         sa.Column("items_spec", sa.String(), nullable=True),
         sa.Column(

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
   alembic
   psycopg2
   httpx~=0.20.0
-  sqlalchemy<1.4.0
+  sqlalchemy
   sqlalchemy-utils
   python-multipart
   uvicorn


### PR DESCRIPTION
Description
---

Fix compatibility with SQLAlchemy>=1.4:
- use `LargeBinary` instead of `Binary`
- also change existing `alembic` migration since `LargeBinary` is a synonym of `Binary` (deprecated since 2010 and removed in `sqlalchemy 1.4.0`, see https://github.com/sqlalchemy/sqlalchemy/issues/6263#issuecomment-819645247)
- remove upper bounds on `conda` and `pip` package deps