### PR TITLE
Automated Changelog Entry for 0.4.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,41 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0
+
+([Full Changelog](https://github.com/mamba-org/quetz/compare/v0.3.0...5f2832c0b39ef56c44c17a0460bc876ae350fae8))
+
+### Enhancements made
+
+- update all js [#501](https://github.com/mamba-org/quetz/pull/501) ([@wolfv](https://github.com/wolfv))
+- attempt to fix CI [#497](https://github.com/mamba-org/quetz/pull/497) ([@wolfv](https://github.com/wolfv))
+- Allow deleting channel members and changing role of existing members [#495](https://github.com/mamba-org/quetz/pull/495) ([@janjagusch](https://github.com/janjagusch))
+- Bump url-parse from 1.4.7 to 1.5.10 in /quetz_frontend [#491](https://github.com/mamba-org/quetz/pull/491) ([@dependabot](https://github.com/dependabot))
+- Make cache timeout for GCS configurable [#490](https://github.com/mamba-org/quetz/pull/490) ([@SophieHallstedtQC](https://github.com/SophieHallstedtQC))
+- Bump follow-redirects from 1.11.0 to 1.14.8 in /quetz_frontend [#487](https://github.com/mamba-org/quetz/pull/487) ([@dependabot](https://github.com/dependabot))
+- Bump ajv from 6.12.2 to 6.12.6 in /quetz_frontend [#486](https://github.com/mamba-org/quetz/pull/486) ([@dependabot](https://github.com/dependabot))
+- Bump node-sass from 4.14.1 to 7.0.0 in /quetz_frontend [#485](https://github.com/mamba-org/quetz/pull/485) ([@dependabot](https://github.com/dependabot))
+- Bump ssri from 6.0.1 to 6.0.2 in /quetz_frontend [#484](https://github.com/mamba-org/quetz/pull/484) ([@dependabot](https://github.com/dependabot))
+- Bump postcss from 7.0.32 to 7.0.39 in /quetz_frontend [#482](https://github.com/mamba-org/quetz/pull/482) ([@dependabot](https://github.com/dependabot))
+
+### Bugs fixed
+
+- make mamba solver work with latest mamba release [#496](https://github.com/mamba-org/quetz/pull/496) ([@wolfv](https://github.com/wolfv))
+
+### Maintenance and upkeep improvements
+
+- fix some pytest and sqlalchemy warnings [#502](https://github.com/mamba-org/quetz/pull/502) ([@wolfv](https://github.com/wolfv))
+- update all js [#501](https://github.com/mamba-org/quetz/pull/501) ([@wolfv](https://github.com/wolfv))
+
+### Other merged PRs
+
+- Bump path-parse from 1.0.6 to 1.0.7 in /quetz_frontend [#498](https://github.com/mamba-org/quetz/pull/498) ([@dependabot](https://github.com/dependabot))
+- Bump lodash from 4.17.19 to 4.17.21 in /quetz_frontend [#483](https://github.com/mamba-org/quetz/pull/483) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/mamba-org/quetz/graphs/contributors?from=2022-02-04&to=2022-03-14&type=c))
+
+[@codecov-commenter](https://github.com/search?q=repo%3Amamba-org%2Fquetz+involves%3Acodecov-commenter+updated%3A2022-02-04..2022-03-14&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Amamba-org%2Fquetz+involves%3Adependabot+updated%3A2022-02-04..2022-03-14&type=Issues) | [@janjagusch](https://github.com/search?q=repo%3Amamba-org%2Fquetz+involves%3Ajanjagusch+updated%3A2022-02-04..2022-03-14&type=Issues) | [@SophieHallstedtQC](https://github.com/search?q=repo%3Amamba-org%2Fquetz+involves%3ASophieHallstedtQC+updated%3A2022-02-04..2022-03-14&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Amamba-org%2Fquetz+involves%3Awolfv+updated%3A2022-02-04..2022-03-14&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | mamba-org/quetz  |
| Branch  | master  |
| Version Spec | 0.4.0 |
| Since | v0.3.0 |