### PR TITLE
Serve repodata.json with redirect

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - typer
   - authlib
   - psycopg2
-  - httpx=0.20.0
+  - httpx=0.22.0
   - sqlalchemy
   - sqlalchemy-utils
   - sqlite

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1602,11 +1602,12 @@ async def stop_sync_donwload_counts():
 @app.head("/get/{channel_name}/{path:path}")
 @app.get("/get/{channel_name}/{path:path}")
 def serve_path(
-    path,
+    path: str,
     channel: db_models.Channel = Depends(get_channel_allow_proxy),
     accept_encoding: Optional[str] = Header(None),
-    session=Depends(get_remote_session),
+    session: dict = Depends(get_remote_session),
     dao: Dao = Depends(get_dao),
+    content_type: Optional[str] = Header(None),
 ):
     is_package_request = path.endswith((".tar.bz2", ".conda"))
     is_repodata_request = path.endswith(".json")
@@ -1653,7 +1654,9 @@ def serve_path(
 
     # Redirect response
     if (is_package_request or is_repodata_request) and pkgstore.support_redirect:
-        return RedirectResponse(pkgstore.url(channel.name, path))
+        return RedirectResponse(
+            pkgstore.url(channel.name, path, content_type=content_type)
+        )
 
     # Streaming response
     if is_repodata_request and accept_encoding and 'gzip' in accept_encoding:

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -572,8 +572,6 @@ class GoogleCloudStorageStore(PackageStore):
 
     @property
     def support_redirect(self):
-        # `gcsfs` currently doesnt support signing yet. Once this is implemented we
-        # can enable this again.
         return True
 
     @contextlib.contextmanager

--- a/quetz/tests/api/test_main.py
+++ b/quetz/tests/api/test_main.py
@@ -5,7 +5,6 @@ from unittest.mock import ANY
 import pytest
 
 from quetz.metrics.db_models import PackageVersionMetric
-from quetz.tasks.indexing import update_indexes
 
 
 def test_index_html(package_version, channel_name, client, mocker):

--- a/quetz/tests/api/test_main.py
+++ b/quetz/tests/api/test_main.py
@@ -16,7 +16,7 @@ def test_index_html(package_version, channel_name, client, mocker):
 
     pkgstore = mocker.Mock()
     pkgstore.get_filemetadata.return_value = (0, 0, "")
-    pkgstore.url.side_effect = lambda chan, p: f"{chan}/{p}"
+    pkgstore.url.side_effect = lambda chan, p, **ignored: f"{chan}/{p}"
     pkgstore.serve_path.side_effect = serve_path
     mocker.patch("quetz.main.pkgstore", pkgstore)
 


### PR DESCRIPTION
Using a redirect is faster than streaming it through the Quetz instance.