### PR TITLE
Move httpx as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
   fastapi
   fsspec
   h2
+  httpx~=0.20.0
   importlib-metadata
   itsdangerous
   jinja2
@@ -72,7 +73,6 @@ client =
 dev =
   black
   flake8
-  httpx~=0.20.0
   isort
   pre-commit
   pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
   alembic
   aiofiles
   appdirs
-  authlib
+  authlib<1.0.0
   fastapi
   fsspec
   h2


### PR DESCRIPTION
httpx is actually an indirect dependency required by the authentication package

This was seen when testing the package for quetz-frontend