### PR TITLE
Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - fastapi
   - typer
-  - authlib
+  - authlib=0.15.5
   - psycopg2
   - httpx=0.20.0
   - sqlalchemy

--- a/quetz/authentication/pam.py
+++ b/quetz/authentication/pam.py
@@ -180,6 +180,5 @@ try:
 
             return username
 
-
 except ImportError:
     PAMAuthenticator = None  # type: ignore


### PR DESCRIPTION
This PR fixes two CI errors:

- It updates the black pre-commit hook and formats the source code according to the new black opinions. This avoids nasty CI errors as in https://github.com/mamba-org/quetz/runs/5837567998?check_suite_focus=true. Background on this error: https://github.com/psf/black/issues/2964.
- It pins `authlib=0.15.0` to avoid `MismatchingStateError` in the testing suite. Background on this error: https://github.com/lepture/authlib/issues/376.
