### PR TITLE
Use infodata['size'] for s3fs

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -387,7 +387,7 @@ class S3Store(PackageStore):
             infodata = fs.info(filepath)
 
             mtime = infodata['LastModified'].timestamp()
-            msize = infodata['Size']
+            msize = infodata['size']
             etag = infodata['ETag']
 
             return (msize, mtime, etag)


### PR DESCRIPTION
After providing both the keys ```Size``` and  ```size``` in S3FileSystem.info. S3Fs has switched to only providing the key [```size```]( https://github.com/fsspec/s3fs/blob/c4fb41f7cc2f2aede6bbb7755096c38b9e4cc553/s3fs/core.py#L1076) which breaks the indexing of an S3Store in quetz on newer S3Fs versions (because quetz currently uses  ```Size```).