### PR TITLE
fix proxy channels noarch and gzip repodata

### DIFF
--- a/quetz/main.py
+++ b/quetz/main.py
@@ -722,7 +722,8 @@ def post_channel(
 
     channel = dao.create_channel(new_channel, user_id, authorization.OWNER, size_limit)
     pkgstore.create_channel(new_channel.name)
-    indexing.update_indexes(dao, pkgstore, new_channel.name)
+    if not is_proxy:
+        indexing.update_indexes(dao, pkgstore, new_channel.name)
 
     # register mirror
     if is_mirror and register_mirror:

--- a/quetz/tasks/mirror.py
+++ b/quetz/tasks/mirror.py
@@ -20,7 +20,7 @@ from quetz.db_models import PackageVersion
 from quetz.errors import DBError
 from quetz.pkgstores import PackageStore
 from quetz.tasks import indexing
-from quetz.utils import TicToc, check_package_membership
+from quetz.utils import TicToc, add_static_file, check_package_membership
 
 # copy common subdirs from conda:
 # https://github.com/conda/conda/blob/a78a2387f26a188991d771967fc33aa1fb5bb810/conda/base/constants.py#L63
@@ -121,7 +121,12 @@ def download_remote_file(
         logger.debug(f"Downloading {path} from {channel} to pkgstore")
         remote_file = repository.open(path)
         data_stream = remote_file.file
-        pkgstore.add_package(data_stream, channel, path)
+
+        if path.endswith('.json'):
+            add_static_file(data_stream.read(), channel, None, path, pkgstore)
+        else:
+            pkgstore.add_package(data_stream, channel, path)
+
     pkgstore.delete_download_lock(channel, path)
 
 


### PR DESCRIPTION
@janjagusch this fixes the `noarch` issue for proxy channels and also adds the same `gzip` mechanism we use with regualr channels which should speed up repodata retrieval substantially (if you're not encoding the stream elsewhere anyways).

Let me know what you think.