### PR TITLE
Add upload endpoint

### DIFF
--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -15,7 +15,7 @@ import tempfile
 from contextlib import contextmanager
 from os import PathLike
 from threading import Lock
-from typing import IO, BinaryIO, List, NoReturn, Tuple, Union
+from typing import IO, List, NoReturn, Tuple, Union
 
 import fsspec
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
@@ -29,7 +29,7 @@ except ImportError:
 
 from quetz.errors import ConfigError
 
-File = BinaryIO
+File = IO[bytes]
 
 StrPath = Union[str, PathLike]
 


### PR DESCRIPTION
This PR adds the api endpoint  ```/channels/{channel_name}/upload/{filename}``` to quetz. The new endpoint includes a mandatory sha256 checksum verification and uses an async ```request.stream``` that is calculating the sha256 checksum while uploading.

An example file upload for  [sqlite-3.37.2-hc67169a_0.tar.bz2](https://beta.mamba.pm/get/emscripten-forge/emscripten-32/sqlite-3.37.2-hc67169a_0.tar.bz2) with curl using the new endpoint looks like this:
```
curl -i -H  "X-API-Key: ${QUETZ_API_KEY}" \
-X POST http://127.0.0.1:8000/api/channels/uptest/upload/sqlite-3.37.2-hc67169a_0.tar.bz2?sha256=63da44f64fb627ad144d38df48b24fb741f8f787027b38219273b40ac75bada9 \
--data-binary @sqlite-3.37.2-hc67169a_0.tar.bz2
```
