### PR TITLE
Fix / consistent usage of f-strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-use-fstring
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.902
     hooks:

--- a/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
+++ b/plugins/quetz_conda_suggest/quetz_conda_suggest/api.py
@@ -15,7 +15,7 @@ router = APIRouter()
 
 @router.get("/api/channels/{channel_name}/{subdir}/conda-suggest")
 def get_conda_suggest(channel_name, subdir, db: Session = Depends(get_db)):
-    map_filename = "{0}.{1}.map".format(channel_name, subdir)
+    map_filename = f"{channel_name}.{subdir}.map"
     map_filepath = pkgstore.url(channel_name, f"{subdir}/{map_filename}")
     try:
         if pkgstore.support_redirect:

--- a/quetz/authentication/auth_dao.py
+++ b/quetz/authentication/auth_dao.py
@@ -94,7 +94,7 @@ def update_user_from_profile(
         if user_email and user_email.user_id != user.id:
             raise IntegrityError(
                 f"User {user.profile.name} already registered"
-                " with email {user_email.email}",
+                f" with email {user_email.email}",
                 "",
                 "",
             )

--- a/quetz/authentication/jupyterhub.py
+++ b/quetz/authentication/jupyterhub.py
@@ -140,7 +140,7 @@ class JupyterhubAuthenticator(OAuthAuthenticator):
         return github_profile
 
     async def _get_user_for_token(self, token):
-        headers = {'Authorization': 'token {}'.format(self.client_secret)}
+        headers = {'Authorization': f'token {self.client_secret}'}
         access_token = quote(token['access_token'], safe='')
 
         # authlib client will be place token in query params

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -146,8 +146,9 @@ def upsert_sql(element, compiler, **kw):
 
     stmt = insert(table).values(values)
     raw_sql = compiler.process(stmt)
-    upsert_stmt = "ON CONFLICT ({}) DO UPDATE SET {}={}+{}".format(
-        ",".join(index_elements), column.name, column.name, incr
+    upsert_stmt = (
+        f"ON CONFLICT ({','.join(index_elements)}) "
+        f"DO UPDATE SET {column.name}={column.name}+{incr}"
     )
 
     return raw_sql + " " + upsert_stmt
@@ -1053,7 +1054,7 @@ class Dao:
                     if user_email:
                         raise IntegrityError(
                             f"User {username} already registered "
-                            "with email {user_email.email}",
+                            f"with email {user_email.email}",
                             "",
                             "",
                         )

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -67,10 +67,7 @@ class date_trunc(FunctionElement):
 def pg_date_trunc(element, compiler, **kw):
     pg_map = {"H": "hour", "D": "day", "M": "month", "Y": "year"}
     period, date = list(element.clauses)
-    return "date_trunc('%s', %s)" % (
-        pg_map[period.value.value],
-        compiler.process(date, **kw),
-    )
+    return f"date_trunc('{pg_map[period.value.value]}', {compiler.process(date, **kw)})"
 
 
 @compiles(date_trunc, 'sqlite')

--- a/quetz/database_extensions.py
+++ b/quetz/database_extensions.py
@@ -45,7 +45,8 @@ if search_path:
     if (plugin_path / "libquetz_pg.so").exists():
         pg_plugin = str((plugin_path / "libquetz_pg.so").resolve())
         logger.info(
-            "Looking for database extension: " "{plugin_path / 'libquetz_pg.so'}: FOUND"
+            "Looking for database extension: "
+            f"{plugin_path / 'libquetz_pg.so'}: FOUND"
         )
     else:
         logger.info(

--- a/quetz/db_models.py
+++ b/quetz/db_models.py
@@ -232,8 +232,8 @@ class Channel(Base):
     def __repr__(self):
         return (
             f"<Channel name={self.name}, "
-            "description={self.description}, "
-            "private={self.private}>"
+            f"description={self.description}, "
+            f"private={self.private}>"
         )
 
 

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -50,7 +50,7 @@ def sqlite_all(element, compiler, **kw):
 
 @compiles(all_true, 'postgresql')
 def pg_all(element, compiler, **kw):
-    return f'bool_and({compiler.process(element.clauses, **kw)}'
+    return f'bool_and({compiler.process(element.clauses, **kw)})'
 
 
 def build_queue(job):

--- a/quetz/jobs/runner.py
+++ b/quetz/jobs/runner.py
@@ -29,12 +29,12 @@ class any_true(FunctionElement):
 
 @compiles(any_true, 'sqlite')
 def sqlite_any(element, compiler, **kw):
-    return 'max(%s)' % compiler.process(element.clauses, **kw)
+    return f'max({compiler.process(element.clauses, **kw)})'
 
 
 @compiles(any_true, 'postgresql')
 def pg_any(element, compiler, **kw):
-    return 'bool_or(%s)' % compiler.process(element.clauses, **kw)
+    return f'bool_or({compiler.process(element.clauses, **kw)})'
 
 
 class all_true(FunctionElement):
@@ -45,12 +45,12 @@ class all_true(FunctionElement):
 
 @compiles(all_true, 'sqlite')
 def sqlite_all(element, compiler, **kw):
-    return 'min(%s)' % compiler.process(element.clauses, **kw)
+    return f'min({compiler.process(element.clauses, **kw)})'
 
 
 @compiles(all_true, 'postgresql')
 def pg_all(element, compiler, **kw):
-    return 'bool_and(%s)' % compiler.process(element.clauses, **kw)
+    return f'bool_and({compiler.process(element.clauses, **kw)}'
 
 
 def build_queue(job):

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1011,7 +1011,7 @@ def post_package_member(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
                 f"Member {new_member.username} in "
-                "{package.channel.name}/{package.name} exists"
+                f"{package.channel.name}/{package.name} exists"
             ),
         )
 
@@ -1446,7 +1446,7 @@ def handle_package_files(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
-                    f"requested package endpoint '{package.name}'"
+                    f"requested package endpoint '{package.name}' "
                     f"does not match the uploaded package name '{parts[0]}'"
                 ),
             )

--- a/quetz/tasks/indexing.py
+++ b/quetz/tasks/indexing.py
@@ -212,7 +212,7 @@ def update_indexes(dao, pkgstore, channel_name, subdirs=None):
             pm.hook.post_index_creation(
                 raw_repodata=raw_repodata, channel_name=channel_name, subdir=sdir
             )
-            logger.debug("Finished post_index_creation for {sdir} of {channel_name}")
+            logger.debug(f"Finished post_index_creation for {sdir} of {channel_name}")
         except Exception:
             logger.exception("Exception post_index_creation:")
 

--- a/quetz/tasks/reindexing.py
+++ b/quetz/tasks/reindexing.py
@@ -98,7 +98,7 @@ def handle_file(channel_name, condainfo, dao, user_id):
         dao.rollback()
         logger.error(
             f"Duplicate package {channel_name}/{package_name}"
-            + "-{condainfo.info['version']}"
+            + f"-{condainfo.info['version']}"
         )
     dao.db.commit()
 

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -730,7 +730,7 @@ def test_filter_jobs_by_status(auth_client, db, user, status, job_ids):
 
     db.commit()
 
-    query = "&".join(["status={}".format(s) for s in status])
+    query = "&".join([f"status={s}" for s in status])
 
     response = auth_client.get(f"/api/jobs?{query}")
 

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -920,9 +920,7 @@ def test_disabled_methods_for_mirror_channels(
     assert "not implemented" in response.json()["detail"]
 
     files = {"files": ("my_package-0.1.tar.bz", "dfdf")}
-    response = client.post(
-        f"/api/channels/{mirror_channel.name}/files/", files=files
-    )
+    response = client.post(f"/api/channels/{mirror_channel.name}/files/", files=files)
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]
 
@@ -968,10 +966,7 @@ def test_repo_without_channeldata(
 
     assert dummy_repo[0] == "http://mirror3_host/channeldata.json"
     for arch in expected_archs:
-        assert (
-            f"http://mirror3_host/{arch}/repodata_from_packages.json"
-            in dummy_repo
-        )
+        assert f"http://mirror3_host/{arch}/repodata_from_packages.json" in dummy_repo
     if expected_archs is KNOWN_SUBDIRS:
         assert len(dummy_repo) == len(expected_archs) * 2 + 1
     else:

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -248,12 +248,12 @@ def test_create_mirror_channel_permissions(
 def test_get_mirror_url(proxy_channel, local_channel, client):
     """test configuring mirror url"""
 
-    response = client.get("/api/channels/{}".format(proxy_channel.name))
+    response = client.get(f"/api/channels/{proxy_channel.name}")
 
     assert response.status_code == 200
     assert response.json()["mirror_channel_url"] == "http://host"
 
-    response = client.get("/api/channels/{}".format(local_channel.name))
+    response = client.get(f"/api/channels/{local_channel.name}")
     assert response.status_code == 200
     assert not response.json()["mirror_channel_url"]
 
@@ -669,7 +669,7 @@ def test_proxy_repodata_cached(client, owner, dummy_repo):
 
 def test_method_not_implemented_for_proxies(client, proxy_channel):
 
-    response = client.post("/api/channels/{}/packages".format(proxy_channel.name))
+    response = client.post(f"/api/channels/{proxy_channel.name}/packages")
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]
 
@@ -677,12 +677,12 @@ def test_method_not_implemented_for_proxies(client, proxy_channel):
 def test_api_methods_for_mirror_channels(client, mirror_channel):
     """mirror-mode channels should have all standard API calls"""
 
-    response = client.get("/api/channels/{}/packages".format(mirror_channel.name))
+    response = client.get(f"/api/channels/{mirror_channel.name}/packages")
     assert response.status_code == 200
     assert not response.json()
 
     response = client.get(
-        "/get/{}/missing/path/file.json".format(mirror_channel.name),
+        f"/get/{mirror_channel.name}/missing/path/file.json",
     )
     assert response.status_code == 404
     assert "file.json not found" in response.json()["detail"]
@@ -902,7 +902,7 @@ def test_write_methods_for_local_channels(auth_client, local_channel, db):
     assert response.status_code == 200
 
     response = auth_client.post(
-        "/api/channels/{}/packages".format(local_channel.name),
+        f"/api/channels/{local_channel.name}/packages",
         json={"name": "my_package"},
     )
     assert response.status_code == 201
@@ -915,19 +915,19 @@ def test_disabled_methods_for_mirror_channels(
     response = client.get("/api/dummylogin/bartosz")
     assert response.status_code == 200
 
-    response = client.post("/api/channels/{}/packages".format(mirror_channel.name))
+    response = client.post(f"/api/channels/{mirror_channel.name}/packages")
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]
 
     files = {"files": ("my_package-0.1.tar.bz", "dfdf")}
     response = client.post(
-        "/api/channels/{}/files/".format(mirror_channel.name), files=files
+        f"/api/channels/{mirror_channel.name}/files/", files=files
     )
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]
 
     response = client.post(
-        "/api/channels/{}/packages/mirror_package/files/".format(mirror_channel.name),
+        f"/api/channels/{mirror_channel.name}/packages/mirror_package/files/",
         files=files,
     )
     assert response.status_code == 405
@@ -969,7 +969,7 @@ def test_repo_without_channeldata(
     assert dummy_repo[0] == "http://mirror3_host/channeldata.json"
     for arch in expected_archs:
         assert (
-            "http://mirror3_host/{}/repodata_from_packages.json".format(arch)
+            f"http://mirror3_host/{arch}/repodata_from_packages.json"
             in dummy_repo
         )
     if expected_archs is KNOWN_SUBDIRS:

--- a/quetz/utils.py
+++ b/quetz/utils.py
@@ -252,7 +252,7 @@ def background_task_wrapper(func: Callable, logger: logging.Logger) -> Callable:
             func_args = inspect.signature(func).bind(*args, **kwargs).arguments
 
             func_args_str = ", ".join(
-                "{}={!r}".format(*item) for item in func_args.items()
+                f"{name}={repr(value)}" for name, value in func_args.items()
             )
 
             logger.error(

--- a/quetz/versionorder.py
+++ b/quetz/versionorder.py
@@ -219,7 +219,7 @@ class VersionOrder:
         return self.norm_version
 
     def __repr__(self):
-        return "%s(\"%s\")" % (self.__class__.__name__, self)
+        return f'{self.__class__.__name__}("{self}")'
 
     def _eq(self, t1, t2):
         for v1, v2 in zip_longest(t1, t2, fillvalue=[]):


### PR DESCRIPTION
Follow-up from #526

* Fix missing `f` for massage strings with placeholders otherwise unresolved.
* Favor f-strings over `.format()` when sensible to do so.
* Replace %-formatting with f-strings.
