### PR TITLE
channels with dots in their name cause a crash in indexing

### DIFF
--- a/quetz/tasks/indexing.py
+++ b/quetz/tasks/indexing.py
@@ -252,6 +252,9 @@ def update_indexes(dao, pkgstore, channel_name, subdirs=None):
     tmp_suffix = uuid.uuid4().hex
     after_upload_move = []
     for path in tempdir_path.rglob('*.*'):
+        # check whether the path is an actual file. this fixes https://github.com/mamba-org/quetz/issues/540
+        if not path.is_file():
+            continue
         rel_path = path.relative_to(tempdir_path)
         to_upload = open(path, 'rb')
         if len(rel_path.parts) == 2:


### PR DESCRIPTION
Solution: skip non-files

fixes #540 