### PR TITLE
Remove package from repodata.json

### DIFF
--- a/quetz/main.py
+++ b/quetz/main.py
@@ -864,8 +864,7 @@ def delete_package(
 
     # get current platform containing the package
     platforms = set([
-        version.platform
-        for version in package.package_versions  # type: ignore
+        version.platform for version in package.package_versions  # type: ignore
     ])
 
     channel_name = package.channel_name

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -861,6 +861,10 @@ def delete_package(
         os.path.join(version.platform, version.filename)
         for version in package.package_versions  # type: ignore
     ]
+
+    # get current platform containing the package
+    platforms = set([version.platform for version in package.package_versions])
+
     channel_name = package.channel_name
 
     db.delete(package)
@@ -873,7 +877,7 @@ def delete_package(
 
     wrapped_bg_task = background_task_wrapper(indexing.update_indexes, logger)
     # Background task to update indexes
-    background_tasks.add_task(wrapped_bg_task, dao, pkgstore, channel_name)
+    background_tasks.add_task(wrapped_bg_task, dao, pkgstore, channel_name, platforms)
 
 
 @api_router.post(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -863,7 +863,10 @@ def delete_package(
     ]
 
     # get current platform containing the package
-    platforms = set([version.platform for version in package.package_versions])
+    platforms = set([
+        version.platform
+        for version in package.package_versions  # type: ignore
+    ])
 
     channel_name = package.channel_name
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -863,9 +863,9 @@ def delete_package(
     ]
 
     # get current platform containing the package
-    platforms = set([
-        version.platform for version in package.package_versions  # type: ignore
-    ])
+    platforms = set(
+        [version.platform for version in package.package_versions]  # type: ignore
+    )
 
     channel_name = package.channel_name
 

--- a/quetz/tasks/indexing.py
+++ b/quetz/tasks/indexing.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2.exceptions import UndefinedError
 
 import quetz.config
 from quetz import channel_data, repo_data
@@ -35,8 +36,11 @@ logger = logging.getLogger("quetz")
 def _iec_bytes(n):
     # Return human-readable string representing n in bytes in IEC format
     for e, f in _iec_prefixes:
-        if n >= e:
-            return f.format(n / e)
+        try:
+            if n >= e:
+                return f.format(n / e)
+        except UndefinedError:
+            logger.debug("Package size is undefined.")
     return f"{n} B"
 
 

--- a/quetz/tasks/indexing.py
+++ b/quetz/tasks/indexing.py
@@ -256,7 +256,8 @@ def update_indexes(dao, pkgstore, channel_name, subdirs=None):
     tmp_suffix = uuid.uuid4().hex
     after_upload_move = []
     for path in tempdir_path.rglob('*.*'):
-        # check whether the path is an actual file. this fixes https://github.com/mamba-org/quetz/issues/540
+        # check whether the path is an actual file.
+        # this fixes https://github.com/mamba-org/quetz/issues/540
         if not path.is_file():
             continue
         rel_path = path.relative_to(tempdir_path)


### PR DESCRIPTION
This PR cleans the `repodata.json` files in all platforms which was containing the removed package.

Fix #475