### PR TITLE
Remove an uploaded package whose filename does not match the package name

### DIFF
--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -307,7 +307,8 @@ def test_upload_package_version_wrong_filename(
     with open(package_filename, "rb") as fid:
         files = {"files": (package_filename, fid)}
         response = auth_client.post(
-            f"/api/channels/{public_channel.name}/packages/" f"{package_name}/files/",
+            f"/api/channels/{public_channel.name}/packages/"
+            f"{public_package.name}/files/",
             files=files,
         )
 


### PR DESCRIPTION
Fixes #553

Also adds a test about package name described in package itself does not match package filename.