### PR TITLE
Add an API for paginated package versions

### DIFF
--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -898,7 +898,12 @@ class Dao:
         return package_version
 
     def get_package_versions(
-        self, package, time_created_ge: datetime = None, version_match_str: str = None
+        self,
+        package,
+        time_created_ge: datetime = None,
+        version_match_str: str = None,
+        skip: int = 0,
+        limit: int = -1,
     ):
         ApiKeyProfile = aliased(Profile)
 
@@ -926,7 +931,10 @@ class Dao:
                     "database_plugin_path correctly for support!"
                 )
 
-        return query.all()
+        if limit < 0:
+            return query.all()
+        else:
+            return get_paginated_result(query, skip, limit)
 
     def get_package_version_by_filename(
         self, channel_name: str, package_name: str, filename: str, platform: str

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1055,6 +1055,35 @@ def get_package_versions(
 
 
 @api_router.get(
+    "/paginated/channels/{channel_name}/packages/{package_name}/versions",
+    response_model=rest_models.PaginatedResponse[rest_models.PackageVersion],
+    tags=["packages"],
+)
+def get_paginated_package_versions(
+    package: db_models.Package = Depends(get_package_or_fail),
+    dao: Dao = Depends(get_dao),
+    skip: int = 0,
+    limit: int = PAGINATION_LIMIT,
+    time_created__ge: datetime.datetime = None,
+    version_match_str: str = None,
+):
+
+    version_profile_list = dao.get_package_versions(
+        package, time_created__ge, version_match_str, skip, limit
+    )
+    version_list = []
+
+    for version, profile, api_key_profile in version_profile_list['result']:
+        version_data = rest_models.PackageVersion.from_orm(version)
+        version_list.append(version_data)
+
+    return {
+        'pagination': version_profile_list['pagination'],
+        'result': version_list,
+    }
+
+
+@api_router.get(
     "/channels/{channel_name}/packages/{package_name}/versions/{platform}/{filename}",
     response_model=rest_models.PackageVersion,
     tags=["packages"],

--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -103,6 +103,22 @@ def test_delete_package_versions_with_package(
     assert files == init_files
 
 
+def test_get_paginated_package_versions(
+    auth_client, public_channel, package_version, dao
+):
+    response = auth_client.get(
+        f"/api/paginated/channels/{public_channel.name}/"
+        f"packages/{package_version.package_name}/versions"
+    )
+
+    assert response.status_code == 200
+    assert isinstance(response.json().get('pagination'), dict)
+    assert response.json().get('pagination').get('all_records_count') == 1
+
+    assert isinstance(response.json().get('result'), list)
+    assert len(response.json().get('result')) == 1
+
+
 def test_get_package_version(auth_client, public_channel, package_version, dao):
     filename = "test-package-0.1-0.tar.bz2"
     platform = "linux-64"


### PR DESCRIPTION
This PR add an API to retrieve paginated package versions, and a basic test on it.