### PR TITLE
no file or directory mandatory

### DIFF
--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -298,7 +298,6 @@ def _is_deployment(base_dir: Path):
     config_file = base_dir.joinpath("config.toml")
     if (
         base_dir.exists()
-        and config_file.exists()
         and base_dir.joinpath("channels").exists()
     ):
         config = Config(str(config_file.resolve()))
@@ -474,9 +473,6 @@ def create(
 def _get_config(path: Union[Path, str]) -> Config:
     """get config path"""
     config_file = Path(path) / 'config.toml'
-    if not config_file.exists():
-        typer.echo(f'Could not find config at {config_file}')
-        raise typer.Abort()
 
     config = Config(str(config_file.resolve()))
     if not os.environ.get(_env_prefix + _env_config_file):

--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -297,10 +297,7 @@ def _fill_test_database(db: Session) -> NoReturn:
 
 def _is_deployment(base_dir: Path):
     config_file = base_dir.joinpath("config.toml")
-    if (
-        base_dir.exists()
-        and base_dir.joinpath("channels").exists()
-    ):
+    if base_dir.exists() and base_dir.joinpath("channels").exists():
         config = Config(str(config_file.resolve()))
         with working_directory(base_dir):
             if not database_exists(config.sqlalchemy_database_url):
@@ -474,7 +471,6 @@ def create(
 def _get_config(path: Union[Path, str]) -> Config:
     """get config path"""
     config_file = Path(path) / 'config.toml'
-
     config = Config(str(config_file.resolve()))
     if not os.environ.get(_env_prefix + _env_config_file):
         os.environ[_env_prefix + _env_config_file] = str(config_file.resolve())
@@ -518,10 +514,12 @@ def start(
         path = os.getcwd()
 
     config = _get_config(deployment_folder)
+
     if not _is_deployment(deployment_folder):
         if isinstance(config.get_package_store(), pkgstores.LocalStore):
             typer.echo(
-                'The specified directory is not a deployment and the package store is set as local.\n'
+                'The specified directory is not a deployment and the package store '
+                'is set as local.\n'
                 'Use the create or run command to create a deployment.',
                 err=True,
             )

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -6,6 +6,7 @@ import logging.config
 import os
 from distutils.util import strtobool
 from secrets import token_bytes
+from tokenize import String
 from typing import (
     Any,
     Dict,
@@ -17,6 +18,7 @@ from typing import (
     Type,
     Union,
 )
+from xmlrpc.client import Boolean
 
 import appdirs
 import pluggy
@@ -287,17 +289,13 @@ class Config:
         if path:
             self.config.update(self._read_config(path))
 
+        self.config.update(self._get_environ_config())
         self._trigger_update_config()
 
     def _trigger_update_config(self):
         def set_entry_attr(entry, section=""):
-            env_var_value = os.getenv(entry.env_var(section))
-            # Override the configuration files if an env variable is defined for
-            # the entry.
-            if env_var_value:
-                value = entry.casted(env_var_value)
-            else:
-                value = self._get_value(entry, section)
+
+            value = self._get_value(entry, section)
 
             setattr(self, entry.full_name(section), value)
 
@@ -368,6 +366,70 @@ class Config:
                 return dict(toml.load(f))
             except toml.TomlDecodeError as e:
                 raise ConfigError(f"failed to load config file '{filename}': {e}")
+
+    def _find_first_level_config(self, section_name: str) -> Union[ConfigSection, ConfigEntry, None]:
+
+        """ Find the section or entry at first level of config_map.
+
+        Parameters
+        ----------
+        section_name : str
+            The name of the section to find.
+
+        Returns
+        -------
+        section : Union[ConfigSection, ConfigEntry, None]
+            The section or entry found, else None.
+        """
+        for item in self._config_map:
+            if section_name == item.name:
+                return item
+        return None
+
+    def _get_environ_config(self) -> Dict[str, Any]:
+        """ Looks into environment variables if some matches with config_map.
+
+        Returns
+        -------
+        configuration : Dict[str, str]
+            The mapping of configuration variables found in environment variables.
+        """
+        config: Dict[str, Any] = {}
+
+        # get QUETZ environment variables.
+        quetz_var = {key: value for key, value in os.environ.items() if key.startswith(_env_prefix)}
+        for var, value in quetz_var.items():
+            splitted_key = var.split('_')
+            config_key = splitted_key[1].lower()
+            idx = 2
+
+            # look for the first level of config_map.
+            # It must be done in loop as the key itself can contains '_'.
+            while (idx < len(splitted_key)):
+                first_level = self._find_first_level_config(config_key)
+                if first_level:
+                    break
+                config_key += f"_{ splitted_key[idx].lower()}"
+                idx += 1
+
+            # no first_level found, the variable is useless.
+            if not first_level:
+                continue
+            # the first level is an entry, add it to the config.
+            if isinstance(first_level, ConfigEntry):
+                config[first_level.name] = value
+            # the first level is a section.
+            elif isinstance(first_level, ConfigSection):
+                entry = "_".join(splitted_key[idx:]).lower()
+                # the entry does not exist in section, the variable is useless.
+                if not entry in [section_entry.name for section_entry in first_level.entries]:
+                    continue
+                # add the entry to the config.
+                if first_level.name not in config:
+                    config[first_level.name]: Dict[str, Any] = {}
+                config[first_level.name]["_".join(splitted_key[idx:]).lower()] = value
+
+        return config
 
     def get_package_store(self) -> pkgstores.PackageStore:
         """Return the appropriate package store as set in the config.

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -6,7 +6,6 @@ import logging.config
 import os
 from distutils.util import strtobool
 from secrets import token_bytes
-from tokenize import String
 from typing import (
     Any,
     Dict,
@@ -18,7 +17,6 @@ from typing import (
     Type,
     Union,
 )
-from xmlrpc.client import Boolean
 
 import appdirs
 import pluggy
@@ -367,9 +365,11 @@ class Config:
             except toml.TomlDecodeError as e:
                 raise ConfigError(f"failed to load config file '{filename}': {e}")
 
-    def _find_first_level_config(self, section_name: str) -> Union[ConfigSection, ConfigEntry, None]:
+    def _find_first_level_config(
+        self, section_name: str
+    ) -> Union[ConfigSection, ConfigEntry, None]:
 
-        """ Find the section or entry at first level of config_map.
+        """Find the section or entry at first level of config_map.
 
         Parameters
         ----------
@@ -387,7 +387,7 @@ class Config:
         return None
 
     def _get_environ_config(self) -> Dict[str, Any]:
-        """ Looks into environment variables if some matches with config_map.
+        """Looks into environment variables if some matches with config_map.
 
         Returns
         -------
@@ -397,7 +397,11 @@ class Config:
         config: Dict[str, Any] = {}
 
         # get QUETZ environment variables.
-        quetz_var = {key: value for key, value in os.environ.items() if key.startswith(_env_prefix)}
+        quetz_var = {
+            key: value
+            for key, value in os.environ.items()
+            if key.startswith(_env_prefix)
+        }
         for var, value in quetz_var.items():
             splitted_key = var.split('_')
             config_key = splitted_key[1].lower()
@@ -405,7 +409,7 @@ class Config:
 
             # look for the first level of config_map.
             # It must be done in loop as the key itself can contains '_'.
-            while (idx < len(splitted_key)):
+            while idx < len(splitted_key):
                 first_level = self._find_first_level_config(config_key)
                 if first_level:
                     break
@@ -422,7 +426,9 @@ class Config:
             elif isinstance(first_level, ConfigSection):
                 entry = "_".join(splitted_key[idx:]).lower()
                 # the entry does not exist in section, the variable is useless.
-                if not entry in [section_entry.name for section_entry in first_level.entries]:
+                if entry not in [
+                    section_entry.name for section_entry in first_level.entries
+                ]:
                     continue
                 # add the entry to the config.
                 if first_level.name not in config:

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -225,7 +225,6 @@ def config(config_str, config_dir, test_data_dir):
 
     Config._instances = {}
     config = Config()
-    print(config_dir)
     yield config
     if "QUETZ_CONFIG_FILE" in os.environ:
         del os.environ["QUETZ_CONFIG_FILE"]

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -3,9 +3,9 @@ import shutil
 import tempfile
 from typing import List
 
+import pytest
 from alembic.command import upgrade as alembic_upgrade
 from fastapi.testclient import TestClient
-import pytest
 
 import quetz
 from quetz.cli import _alembic_config
@@ -16,7 +16,9 @@ from quetz.db_models import Base
 
 
 def pytest_configure(config):
-    pytest.quetz_variables = {var: value for var, value in os.environ.items() if var.startswith("QUETZ_")}
+    pytest.quetz_variables = {
+        var: value for var, value in os.environ.items() if var.startswith("QUETZ_")
+    }
     for var in pytest.quetz_variables:
         del os.environ[var]
 

--- a/quetz/tests/test_cli.py
+++ b/quetz/tests/test_cli.py
@@ -550,18 +550,16 @@ def database_url_environment_variables() -> None:
 
 @pytest.fixture()
 def mandatory_environment_variables(
-    database_url_environment_variables: None,
-    session_secret_environment_variables: None
+    database_url_environment_variables: None, session_secret_environment_variables: None
 ) -> None:
     yield
 
 
 @pytest.mark.timeout(1)
 def test_start_without_database_url(
-    empty_config_on_exit: None,
-    session_secret_environment_variables:  None
+    empty_config_on_exit: None, session_secret_environment_variables: None
 ):
-    """ Error starting server without database url """
+    """Error starting server without database url"""
     res = runner.invoke(cli.app, ["start"])
     assert res.exit_code == 1
     assert "'database_url' unset" in str(res.exception)
@@ -569,10 +567,9 @@ def test_start_without_database_url(
 
 @pytest.mark.timeout(1)
 def test_start_without_session_secret(
-    empty_config_on_exit: None,
-    database_url_environment_variables: None
+    empty_config_on_exit: None, database_url_environment_variables: None
 ):
-    """ Error starting server without session secret """
+    """Error starting server without session secret"""
     res = runner.invoke(cli.app, ["start"])
     assert res.exit_code == 1
     assert "'secret' unset" in str(res.exception)
@@ -580,10 +577,9 @@ def test_start_without_session_secret(
 
 @pytest.mark.timeout(1)
 def test_start_server_local_without_deployment(
-    empty_config_on_exit: None,
-    mandatory_environment_variables: None
+    empty_config_on_exit: None, mandatory_environment_variables: None
 ):
-    """ Error starting server without deployment directory """
+    """Error starting server without deployment directory"""
     res = runner.invoke(cli.app, ["start"])
     assert res.exit_code == 1
     assert "The specified directory is not a deployment" in res.output

--- a/quetz/tests/test_config.py
+++ b/quetz/tests/test_config.py
@@ -25,8 +25,6 @@ def test_config_without_file_path_set(config_str):
 
     # we need to check whether Config was not initialised before
     assert not Config._instances
-    with pytest.raises(ValueError, match="Environment"):
-        Config()
 
     # check if it works with path even if QUETZ_CONFIG_FILE is
     # not defined

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ universal = 1
 include_package_data = True
 packages = find:
 python_requires = >=3.7
-  
+
 install_requires =
   alembic
   aiofiles
@@ -56,7 +56,7 @@ azure =
   adlfs
 gcs =
   gcsfs >=2022.02
-pam = 
+pam =
   pamela
 postgre =
   psycopg2
@@ -79,6 +79,7 @@ dev =
   pytest-asyncio
   pytest-mock
   pytest-cov
+  pytest-timeout
   tbump
 test =
   %(dev)s


### PR DESCRIPTION
This PR should fix #459

The config file is now not mandatory, but the server will not start if one of the variables `$QUETZ_SQLALCHEMY_DATABASE_URL` and `$QUETZ_SESSION_SECRET` is missing.
The deployment directory is not mandatory either if the store is not a `LocalStore`. In fact if any other available store has a variable defined.

This also adds some basic tests to ensure server does not start without minimal settings.

**MISSING TESTS** : make sure the server starts correctly without settings file but with environment variables. Haven't found a way to kill it cleanly, so all following tests will fail with `Address already in use`.