### PR TITLE
Fixes CI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.7
   - pip
-  - fastapi
+  - fastapi=0.79
   - typer
   - authlib=0.15.5
   - psycopg2


### PR DESCRIPTION
This PR pins FastAPI to check whether the error comes from [this release of FastAPI](https://github.com/tiangolo/fastapi/releases/tag/0.80.0)