### PR TITLE
fix package_versions.version_order database field after package version deletion

### DIFF
--- a/quetz/cli.py
+++ b/quetz/cli.py
@@ -455,7 +455,7 @@ def create(
             config = Config()
             db_path = os.getcwd()
         except Exception as e:
-            logger.warn(msg=e)
+            logger.warning(msg=e)
             typer.echo(
                 'No configuration file provided.\n'
                 'Use --create-conf or --copy-conf to produce a config file\n'

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -335,12 +335,14 @@ class Dao:
 
         return channel
 
-    def cleanup_channel_db(self, channel_name: str, dry_run: bool = False):
+    def cleanup_channel_db(self, channel_name: str, package_name: Optional[str] = None, dry_run: bool = False):
         # remove all Packages without PackageVersions
         package_without_package_versions = []
         all_packages = self.db.query(Package).filter(
             Package.channel_name == channel_name
         )
+        if package_name:
+            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
         for each_package in all_packages:
             all_package_versions = (
                 self.db.query(PackageVersion)
@@ -372,6 +374,8 @@ class Dao:
         all_packages = self.db.query(Package).filter(
             Package.channel_name == channel_name
         )
+        if package_name:
+            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
         for each_package in all_packages:
             if each_package.channeldata is not None:
                 each_package_channeldata = json.loads(each_package.channeldata)
@@ -392,12 +396,17 @@ class Dao:
 
         if not dry_run:
             self.db.commit()
-        logger.info(f"Done cleaning up db for {channel_name}")
+        if not package_name:
+            logger.info(f"Done cleaning up db for {channel_name}")
+        else:
+            logger.info(f"Done cleaning up db for {channel_name}/{package_name}")
 
         # Re-sort all PackageVersions
         all_packages = self.db.query(Package).filter(
             Package.channel_name == channel_name
         )
+        if package_name:
+            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
         for x, each_package in enumerate(all_packages):
             all_versions_for_each_package = (
                 self.db.query(PackageVersion)
@@ -425,7 +434,10 @@ class Dao:
 
         if not dry_run:
             self.db.commit()
-        logger.info(f"Done sorting package versions for {channel_name}")
+        if not package_name:
+            logger.info(f"Done sorting package versions for {channel_name}")
+        else:
+            logger.info(f"Done sorting package versions for {channel_name}/{package_name}")
 
     def create_channel_mirror(
         self, channel_name: str, url: str, api_endpoint: str, metrics_endpoint: str

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -335,14 +335,21 @@ class Dao:
 
         return channel
 
-    def cleanup_channel_db(self, channel_name: str, package_name: Optional[str] = None, dry_run: bool = False):
+    def cleanup_channel_db(
+        self,
+        channel_name: str,
+        package_name: Optional[str] = None,
+        dry_run: bool = False,
+    ):
         # remove all Packages without PackageVersions
         package_without_package_versions = []
         all_packages = self.db.query(Package).filter(
             Package.channel_name == channel_name
         )
         if package_name:
-            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
+            all_packages = all_packages.filter(
+                PackageVersion.package_name == package_name
+            )
         for each_package in all_packages:
             all_package_versions = (
                 self.db.query(PackageVersion)
@@ -375,7 +382,9 @@ class Dao:
             Package.channel_name == channel_name
         )
         if package_name:
-            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
+            all_packages = all_packages.filter(
+                PackageVersion.package_name == package_name
+            )
         for each_package in all_packages:
             if each_package.channeldata is not None:
                 each_package_channeldata = json.loads(each_package.channeldata)
@@ -406,7 +415,9 @@ class Dao:
             Package.channel_name == channel_name
         )
         if package_name:
-            all_packages = all_packages.filter(PackageVersion.package_name == package_name)
+            all_packages = all_packages.filter(
+                PackageVersion.package_name == package_name
+            )
         for x, each_package in enumerate(all_packages):
             all_versions_for_each_package = (
                 self.db.query(PackageVersion)
@@ -437,7 +448,9 @@ class Dao:
         if not package_name:
             logger.info(f"Done sorting package versions for {channel_name}")
         else:
-            logger.info(f"Done sorting package versions for {channel_name}/{package_name}")
+            logger.info(
+                f"Done sorting package versions for {channel_name}/{package_name}"
+            )
 
     def create_channel_mirror(
         self, channel_name: str, url: str, api_endpoint: str, metrics_endpoint: str

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1140,7 +1140,7 @@ def delete_package_version(
     path = os.path.join(platform, filename)
     pkgstore.delete_file(channel_name, path)
 
-    dao.cleanup_channel_db(channel_name)
+    dao.cleanup_channel_db(channel_name, package_name)
     dao.update_channel_size(channel_name)
 
     wrapped_bg_task = background_task_wrapper(indexing.update_indexes, logger)

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1140,6 +1140,7 @@ def delete_package_version(
     path = os.path.join(platform, filename)
     pkgstore.delete_file(channel_name, path)
 
+    dao.cleanup_channel_db(channel_name)
     dao.update_channel_size(channel_name)
 
     wrapped_bg_task = background_task_wrapper(indexing.update_indexes, logger)

--- a/quetz/tasks/cleanup.py
+++ b/quetz/tasks/cleanup.py
@@ -3,7 +3,7 @@ from quetz.pkgstores import PackageStore
 
 
 def cleanup_channel_db(dao: Dao, channel_name: str, dry_run: bool):
-    dao.cleanup_channel_db(channel_name, dry_run)
+    dao.cleanup_channel_db(channel_name, None, dry_run)
 
 
 def cleanup_temp_files(pkgstore: PackageStore, channel_name: str, dry_run: bool):


### PR DESCRIPTION
fixes #560 by regenerating the `package_versions` table after deleting the package

**Note:** This does NOT fix the issue where *uploading* multiple packages at once will result in inconsistent `version_order` values. 
The inconsistency is shown in the mentioned issue as well, but I'm not sure if it has any negative implications.