### PR TITLE
Add 'dependencies' to PR labels

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -2,7 +2,7 @@ name: Enforce PR label
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled, opened, edited, synchronize, dependencies]
 
 jobs:
   enforce-label:


### PR DESCRIPTION
This should make CI pass in `dependabot` PRs, like https://github.com/mamba-org/quetz/pull/566.