### PR TITLE
Remove `httpx` pin, fix tests, & test plugins individually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo hello
 
       - name: Step 2
-        shell: bash -l {0}
+        shell: bash -l +e -o pipefail {0}
         run: |
           cat abc
           echo hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,12 +118,12 @@ jobs:
             quetz plugin install $f
             pytest -v $f
             if [ $? -ne 0 ]; then
-              $tests_failed = 1
+              tests_failed = 1
             fi
             echo "::endgroup::"
           done
 
-          if [ $tests_failed -eq 1 ]; then
+          if [ "$tests_failed" -eq 1 ]; then
             echo "::error::Some plugin tests failed!"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,13 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      - uses: actions/checkout@v2
+
       - name: Check status code
         shell: bash -l {0}
         run: |
           cat abc
           echo hello
-      - uses: actions/checkout@v2
 
       - name: install mamba
         uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v2
+      - name: install mamba
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Check status code
         shell: bash -l -e {0}
@@ -59,9 +61,7 @@ jobs:
         run: |
           cat abc
           echo hello
-
-      - name: install mamba
-        uses: mamba-org/provision-with-micromamba@main
+        
       - name: test quetz
         shell: bash -l -eo pipefail {0}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Step 2
         shell: bash -l +e -o pipefail {0}
         run: |
+          set +e
           cat abc
           echo hello
 
@@ -61,7 +62,7 @@ jobs:
         run: |
           cat abc
           echo hello
-        
+
       - name: test quetz
         shell: bash -l -eo pipefail {0}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
           pytest -v ./quetz/tests/ --cov-config=.coveragerc --cov=. --cov-report=xml
 
       - name: Test the plugins
-        shell: bash -l -eo pipefail {0}
+        id: test_plugins
+        shell: bash -l {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
           QUETZ_TEST_DBINIT: ${{ matrix.db_init }}
@@ -106,15 +107,25 @@ jobs:
           export PATH=$(dirname $MAMBA_EXE):$PATH
           echo "adding micromamba to path: $MAMBA_EXE"
 
-          pip install --no-deps git+https://git@github.com/regro/libcflib@master
+          pip install --no-deps git+https://git@github.com/regro/libcflib@master || exit 1
           
           for f in ./plugins/quetz_*
           do
             echo "::group::Testing plugin${f}"
             quetz plugin install $f
             pytest -v $f
+            if [ $? -ne 0 ]; then
+              echo "tests_failed=true" >> $GITHUB_OUTPUT
+            fi
             echo "::endgroup::"
           done
+
+      - name: Check if tests failed
+        run: |
+          if [ ${{ steps.test_plugins.outputs.tests_failed }} == "true" ]; then
+            echo "Some of the plugin tests failed!"
+            exit 1
+          fi
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,12 +118,12 @@ jobs:
             quetz plugin install $f
             pytest -v $f
             if [ $? -ne 0 ]; then
-              tests_failed = 1
+              tests_failed="true"
             fi
             echo "::endgroup::"
           done
 
-          if [ "$tests_failed" -eq 1 ]; then
+          if [ "$tests_failed" -eq "true" ]; then
             echo "::error::Some plugin tests failed!"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           S3_ENDPOINT: https://s3.sbg.cloud.ovh.net/
           S3_REGION: sbg
         run: |
-
           if [ "$TEST_DB_BACKEND" == "postgres" ]; then
             export QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
             echo "Running with postgres"
@@ -111,18 +110,19 @@ jobs:
           
           for f in ./plugins/quetz_*
           do
-            echo "::group::Testing plugin${f}"
+            echo "::group::Testing plugin ${f}"
             quetz plugin install $f
 
             # We want to test all the plugins, regardless of whether one fails
             set +e
             pytest -v $f
-            if [ $? -ne 0 ]; then
+            pytest_exit_code=$?
+            set -e
+            echo "::endgroup::"
+            if [ $pytest_exit_code -ne 0 ]; then
               echo "::error::Tests for plugin $f failed!"
               tests_failed="true"
             fi
-            set -e
-            echo "::endgroup::"
           done
 
           if [ "$tests_failed" == "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           pytest -v ./quetz/tests/ --cov-config=.coveragerc --cov=. --cov-report=xml
 
       - name: Test the plugins
-        id: test_plugins
+        shell: bash -l -eo pipefail {0}
         shell: bash -l {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
@@ -98,8 +98,6 @@ jobs:
           S3_ENDPOINT: https://s3.sbg.cloud.ovh.net/
           S3_REGION: sbg
         run: |
-          # We want to test all the plugins, regardless of whether one fails
-          set +e
 
           if [ "$TEST_DB_BACKEND" == "postgres" ]; then
             export QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
@@ -110,20 +108,24 @@ jobs:
           export PATH=$(dirname $MAMBA_EXE):$PATH
           echo "adding micromamba to path: $MAMBA_EXE"
 
-          pip install --no-deps git+https://git@github.com/regro/libcflib@master || exit 1
+          pip install --no-deps git+https://git@github.com/regro/libcflib@master
           
           for f in ./plugins/quetz_*
           do
             echo "::group::Testing plugin${f}"
             quetz plugin install $f
+
+            # We want to test all the plugins, regardless of whether one fails
+            set +e
             pytest -v $f
             if [ $? -ne 0 ]; then
               tests_failed="true"
             fi
+            set -e
             echo "::endgroup::"
           done
 
-          if [ "$tests_failed" -eq "true" ]; then
+          if [ "$tests_failed" == "true" ]; then
             echo "::error::Some plugin tests failed!"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Test the plugins
         shell: bash -l -eo pipefail {0}
-        shell: bash -l {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
           QUETZ_TEST_DBINIT: ${{ matrix.db_init }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo hello
 
       - name: Step 2
-        shell: bash -l -e -o pipefail {0}
+        shell: bash -l +e -o pipefail {0}
         run: |
           cat abc
           echo hello
@@ -105,7 +105,7 @@ jobs:
 
       - name: Test the plugins
         id: test_plugins
-        shell: bash +e -l -o pipefail {0}
+        shell: bash -l +e -o pipefail {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
           QUETZ_TEST_DBINIT: ${{ matrix.db_init }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      - name: Check status code
+        shell: bash -l {0}
+        run: |
+          cat abc
+          echo hello
       - uses: actions/checkout@v2
 
       - name: install mamba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo hello
 
       - name: Step 2
-        shell: bash -l +e -o pipefail {0}
+        shell: bash -l -e -o pipefail {0}
         run: |
           cat abc
           echo hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,19 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check status code
+        shell: bash -l -e {0}
+        run: |
+          echo hello
+
+      - name: Step 2
         shell: bash -l {0}
+        run: |
+          cat abc
+          echo hello
+
+      - name: Step 3
+        if: always()
+        shell: bash -l +e {0}
         run: |
           cat abc
           echo hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,28 +41,9 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v2
+
       - name: install mamba
         uses: mamba-org/provision-with-micromamba@main
-
-      - name: Check status code
-        shell: bash -l -e {0}
-        run: |
-          echo hello
-
-      - name: Step 2
-        shell: bash -l +e -o pipefail {0}
-        run: |
-          set +e
-          cat abc
-          echo hello
-
-      - name: Step 3
-        if: always()
-        shell: bash -l +e {0}
-        run: |
-          cat abc
-          echo hello
-
       - name: test quetz
         shell: bash -l -eo pipefail {0}
         env:
@@ -106,7 +87,7 @@ jobs:
 
       - name: Test the plugins
         id: test_plugins
-        shell: bash -l +e -o pipefail {0}
+        shell: bash -l {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
           QUETZ_TEST_DBINIT: ${{ matrix.db_init }}
@@ -117,7 +98,8 @@ jobs:
           S3_ENDPOINT: https://s3.sbg.cloud.ovh.net/
           S3_REGION: sbg
         run: |
-          cat abc
+          # We want to test all the plugins, regardless of whether one fails
+          set +e
 
           if [ "$TEST_DB_BACKEND" == "postgres" ]; then
             export QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
@@ -130,24 +112,19 @@ jobs:
 
           pip install --no-deps git+https://git@github.com/regro/libcflib@master || exit 1
           
-          cat abc
-
           for f in ./plugins/quetz_*
           do
-            cat abc
             echo "::group::Testing plugin${f}"
             quetz plugin install $f
             pytest -v $f
             if [ $? -ne 0 ]; then
-              echo "tests_failed=true" >> $GITHUB_OUTPUT
+              $tests_failed = 1
             fi
             echo "::endgroup::"
           done
 
-      - name: Check if tests failed
-        run: |
-          if [ ${{ steps.test_plugins.outputs.tests_failed }} == "true" ]; then
-            echo "Some of the plugin tests failed!"
+          if [ $tests_failed -eq 1 ]; then
+            echo "::error::Some plugin tests failed!"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Test the plugins
         id: test_plugins
-        shell: bash -l {0}
+        shell: bash +e -l -o pipefail {0}
         env:
           TEST_DB_BACKEND: ${{ matrix.test_database }}
           QUETZ_TEST_DBINIT: ${{ matrix.db_init }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             set +e
             pytest -v $f
             if [ $? -ne 0 ]; then
+              echo "::error::Tests for plugin $f failed!"
               tests_failed="true"
             fi
             set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
           S3_ENDPOINT: https://s3.sbg.cloud.ovh.net/
           S3_REGION: sbg
         run: |
+          cat abc
+
           if [ "$TEST_DB_BACKEND" == "postgres" ]; then
             export QUETZ_TEST_DATABASE="postgresql://postgres:mysecretpassword@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
             echo "Running with postgres"
@@ -115,8 +117,11 @@ jobs:
 
           pip install --no-deps git+https://git@github.com/regro/libcflib@master || exit 1
           
+          cat abc
+
           for f in ./plugins/quetz_*
           do
+            cat abc
             echo "::group::Testing plugin${f}"
             quetz plugin install $f
             pytest -v $f

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8/
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/flake8/
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - typer
   - authlib=0.15.5
   - psycopg2
-  - httpx=0.20.0
   - sqlalchemy
   - sqlalchemy-utils
   - sqlite

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - typer
   - authlib=0.15.5
   - psycopg2
+  - httpx>=0.22.0
   - sqlalchemy
   - sqlalchemy-utils
   - sqlite

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - typer
   - authlib=0.15.5
   - psycopg2
-  - httpx=0.20.0
+  - httpx>=0.22.0
   - sqlalchemy
   - sqlalchemy-utils
   - sqlite

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - typer
   - authlib=0.15.5
   - psycopg2
-  - httpx>=0.22.0
+  - httpx=0.20.0
   - sqlalchemy
   - sqlalchemy-utils
   - sqlite

--- a/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
+++ b/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
@@ -23,6 +23,7 @@ def test_valid_login(client, db, testuser, testpassword):
     response = client.post(
         "/auth/sql/authorize",
         data={"username": testuser, "password": testpassword},
+        allow_redirects=False,
     )
     # Assert that we get a redirect to the main page
     assert response.status_code == 303
@@ -204,6 +205,7 @@ def test_changing_password(owner_client, client, db, testuser, testpassword):
     response = client.post(
         "/auth/sql/authorize",
         data={"username": testuser, "password": testpassword},
+        allow_redirects=False,
     )
     # Assert that we get a redirect to the main page
     assert response.status_code == 303
@@ -237,6 +239,7 @@ def test_changing_password(owner_client, client, db, testuser, testpassword):
     response = client.post(
         "/auth/sql/authorize",
         data={"username": testuser, "password": newpassword},
+        allow_redirects=False,
     )
     # Assert that we get a redirect to the main page
     assert response.status_code == 303

--- a/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
+++ b/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
@@ -23,7 +23,7 @@ def test_valid_login(client, db, testuser, testpassword):
     response = client.post(
         "/auth/sql/authorize",
         data={"username": testuser, "password": testpassword},
-        allow_redirects=False,
+        # allow_redirects=False,
     )
     # Assert that we get a redirect to the main page
     assert response.status_code == 303

--- a/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
+++ b/plugins/quetz_sql_authenticator/tests/test_quetz_sql_authenticator.py
@@ -23,7 +23,7 @@ def test_valid_login(client, db, testuser, testpassword):
     response = client.post(
         "/auth/sql/authorize",
         data={"username": testuser, "password": testpassword},
-        # allow_redirects=False,
+        allow_redirects=False,
     )
     # Assert that we get a redirect to the main page
     assert response.status_code == 303

--- a/plugins/quetz_tos/tests/test_quetz_tos.py
+++ b/plugins/quetz_tos/tests/test_quetz_tos.py
@@ -1,5 +1,3 @@
-import io
-
 import pytest
 from fastapi import HTTPException
 
@@ -13,8 +11,8 @@ def upload_tos(client):
     url = "/api/tos/upload?lang=EN&lang=FR"
 
     files_to_upload = (
-        ('tos_files', ("tos_en.txt", io.StringIO("demo tos en"))),
-        ('tos_files', ("tos_fr.txt", io.StringIO("demo tos fr"))),
+        ('tos_files', ("tos_en.txt", b"demo tos en")),
+        ('tos_files', ("tos_fr.txt", b"demo tos fr")),
     )
 
     response = client.post(url, files=files_to_upload)

--- a/quetz/tests/api/test_channels.py
+++ b/quetz/tests/api/test_channels.py
@@ -707,7 +707,9 @@ def test_url_with_slash(auth_client, public_channel, db, remote_session):
     mirror_url = "http://mirror_url"
 
     response = auth_client.post(
-        f"/api/channels/{public_channel.name}/mirrors/", json={"url": mirror_url}
+        f"/api/channels/{public_channel.name}/mirrors/",
+        json={"url": mirror_url},
+        allow_redirects=False,
     )
 
     assert response.status_code == 307

--- a/quetz/tests/api/test_main.py
+++ b/quetz/tests/api/test_main.py
@@ -149,7 +149,7 @@ def test_delete_channel_member_no_member(auth_client, public_channel, other_user
 
 
 def test_upload_wrong_file_type(auth_client, public_channel):
-    files = {"files": ("my_package-0.1-0.tar.bz", "dfdf")}
+    files = {"files": ("my_package-0.1-0.tar.bz", b"dfdf")}
     response = auth_client.post(
         f"/api/channels/{public_channel.name}/files/", files=files
     )

--- a/quetz/tests/test_auth.py
+++ b/quetz/tests/test_auth.py
@@ -393,13 +393,13 @@ def test_private_channels(data, client):
 def test_private_channels_create_package(data, client):
     # public access to public channel
     response = client.post(
-        f'/api/channels/{data.channel1.name}/packages', '{"name": "newpackage1"}'
+        f'/api/channels/{data.channel1.name}/packages', json={"name": "newpackage1"}
     )
     assert response.status_code == 401
 
     # public access to private channel
     response = client.post(
-        f'/api/channels/{data.channel2.name}/packages', '{"name": "newpackage1"}'
+        f'/api/channels/{data.channel2.name}/packages', json={"name": "newpackage1"}
     )
     assert response.status_code == 401
 

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -926,7 +926,6 @@ def test_disabled_methods_for_mirror_channels(
     assert "not implemented" in response.json()["detail"]
 
     files = {"files": ("my_package-0.1.tar.bz", b"dfdf")}
-    DUMMY_PACKAGE
     response = client.post(f"/api/channels/{mirror_channel.name}/files/", files=files)
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -792,13 +792,19 @@ def test_add_and_register_mirror(auth_client, dummy_session_mock):
     )
     assert response.status_code == 201
 
+    base_url = auth_client.base_url
+    base_url_path = auth_client.base_url.path
+
     dummy_session_mock.post.assert_called_with(
         "http://mirror3_host/api/channels/my-channel/mirrors",
         json={
-            "url": auth_client.base_url + '/get/mirror-channel',
-            "api_endpoint": auth_client.base_url + '/api/channels/mirror-channel',
-            "metrics_endpoint": auth_client.base_url
-            + '/metrics/channels/mirror-channel',
+            "url": base_url.copy_with(path=base_url_path + 'get/mirror-channel'),
+            "api_endpoint": base_url.copy_with(
+                path=base_url_path + 'api/channels/mirror-channel'
+            ),
+            "metrics_endpoint": base_url.copy_with(
+                path=base_url_path + 'metrics/channels/mirror-channel'
+            ),
         },
         headers={},
     )
@@ -919,7 +925,8 @@ def test_disabled_methods_for_mirror_channels(
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]
 
-    files = {"files": ("my_package-0.1.tar.bz", "dfdf")}
+    files = {"files": ("my_package-0.1.tar.bz", b"dfdf")}
+    DUMMY_PACKAGE
     response = client.post(f"/api/channels/{mirror_channel.name}/files/", files=files)
     assert response.status_code == 405
     assert "not implemented" in response.json()["detail"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
   fastapi
   fsspec
   h2
+  httpx>=0.22.0
   importlib-metadata
   itsdangerous
   jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
   fastapi
   fsspec
   h2
-  httpx~=0.20.0
   importlib-metadata
   itsdangerous
   jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
   fastapi
   fsspec
   h2
-  httpx~=0.20.0
+  httpx>=0.22.0
   importlib-metadata
   itsdangerous
   jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
   fastapi
   fsspec
   h2
-  httpx>=0.22.0
+  httpx~=0.20.0
   importlib-metadata
   itsdangerous
   jinja2


### PR DESCRIPTION
This PR removes the pin on `httpx`, which was causing issues with newer versions of `starlette` which require `httpx>=0.22.0`.
See https://github.com/conda-forge/quetz-feedstock/issues/24.

- Fixed the tests which required changes to work with `httpx>=0.22.0`
- Changed plugin testing to not abort when tests have failed for one plugin