### PR TITLE
use use raise_for_status instead of printing empty response.json()

### DIFF
--- a/quetz_client/quetz_client/command_line.py
+++ b/quetz_client/quetz_client/command_line.py
@@ -74,7 +74,7 @@ def create_channel(args):
         # "mirror_mode": "string"
     }
     response = requests.post(url, json=json_data, headers={'X-API-Key': api_key})
-    print(response.json())
+    response.raise_for_status()
 
 
 def urljoin_all(pieces):


### PR DESCRIPTION
when successfully creating a channel, the quetz-client  prints None
```
quetz-client create-channel emscripten-forge-bootstrap 
None
```
because we do `print(response.json())`.
We should rather do `response.raise_for_status()` which will throw an error when we get a error indicating HTML return code.