### PR TITLE
Add sampler profiling

### DIFF
--- a/dev_config.toml
+++ b/dev_config.toml
@@ -18,3 +18,7 @@ file = "quetz.log"
 
 [users]
 admins = ["dummy:alice"]
+
+[profiling]
+enable_sampling = true
+

--- a/dev_config.toml
+++ b/dev_config.toml
@@ -20,5 +20,5 @@ file = "quetz.log"
 admins = ["dummy:alice"]
 
 [profiling]
-enable_sampling = true
+enable_sampling = false
 

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -225,6 +225,16 @@ You can configure the limits (quota) on the size of uploaded packages for each c
 
 :channel_quota: maximum total size (in bytes) of packages uploaded to the channel
 
+``profiling`` section
+^^^^^^^^^^^^^^^^^^^^^
+
+Quetz provides instrumentation for profiling its endpoints.
+
+:enable_sampling: enables sampling profiling by providing the query parameter `profile=true` (or any truth value) to the request.
+When active and provided the query parameter, the returned response will be highjacked to provide an HTML version of the profile output.
+
+:interval_seconds: sampling interval in seconds. If not set, it has a default value of `0.001`.
+
 Environment
 -----------
 

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -230,8 +230,7 @@ You can configure the limits (quota) on the size of uploaded packages for each c
 
 Quetz provides instrumentation for profiling its endpoints.
 
-:enable_sampling: enables sampling profiling by providing the query parameter `profile=true` (or any truth value) to the request.
-When active and provided the query parameter, the returned response will be highjacked to provide an HTML version of the profile output.
+:enable_sampling: enables sampling profiling by providing the query parameter `profile=true` (or any truth value) to the request. When active and provided the query parameter, the returned response will be highjacked to provide an HTML version of the profile output.
 
 :interval_seconds: sampling interval in seconds. If not set, it has a default value of `0.001`.
 

--- a/environment.yml
+++ b/environment.yml
@@ -47,5 +47,6 @@ dependencies:
   - libcflib
   - mamba
   - conda-content-trust
+  - pyinstrument
   - pip:
       - git+https://github.com/jupyter-server/jupyter_releaser.git@v2

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -214,6 +214,14 @@ class Config:
             ],
             required=False,
         ),
+        ConfigSection(
+            "profiling",
+            [
+                ConfigEntry("enable_sampling", bool, required=False, default=False),
+                ConfigEntry("interval_seconds", float, required=False, default=0.001),
+            ],
+            required=False,
+        ),
     ]
     _config_dirs = [_site_dir, _user_dir]
     _config_files = [os.path.join(d, _filename) for d in _config_dirs]

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -165,28 +165,24 @@ class CondaTokenMiddleware(BaseHTTPMiddleware):
 app.add_middleware(CondaTokenMiddleware)
 
 
-if config.profiling_enable_sampling:
-    try:
-        from pyinstrument.profiler import Profiler
-    except ModuleNotFoundError:
-        logger.warning("'pyinstrument' was not found, proceeding without profiling.")
-    else:
+if config.configured_section("profiling") and config.profiling_enable_sampling:
+    from pyinstrument.profiler import Profiler
 
-        @app.middleware("http")
-        async def profile_request(
-            request: Request,
-            call_next: Callable[[Request], Awaitable[Response]],
-        ):
-            if not request.query_params.get("profile", False):
-                return await call_next(request)
-            profiler = Profiler(
-                interval=config.profiling_interval_seconds,
-                async_mode="enabled",
-            )
-            profiler.start()
-            await call_next(request)
-            profiler.stop()
-            return HTMLResponse(profiler.output_html())
+    @app.middleware("http")
+    async def profile_request(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ):
+        if not request.query_params.get("profile", False):
+            return await call_next(request)
+        profiler = Profiler(
+            interval=config.profiling_interval_seconds,
+            async_mode="enabled",
+        )
+        profiler.start()
+        await call_next(request)
+        profiler.stop()
+        return HTMLResponse(profiler.output_html())
 
 
 pkgstore = config.get_package_store()

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from email.utils import formatdate
 from tempfile import SpooledTemporaryFile, TemporaryFile
-from typing import List, Optional, Tuple, Type
+from typing import Awaitable, Callable, List, Optional, Tuple, Type
 
 import pydantic
 import pydantic.error_wrappers
@@ -29,12 +29,13 @@ from fastapi import (
     Header,
     HTTPException,
     Request,
+    Response,
     UploadFile,
     responses,
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from importlib_metadata import entry_points
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -162,6 +163,31 @@ class CondaTokenMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(CondaTokenMiddleware)
+
+
+if config.profiling_enable_sampling:
+    try:
+        from pyinstrument.profiler import Profiler
+    except ModuleNotFoundError:
+        logger.warning("'pyinstrument' was not found, proceeding without profiling.")
+    else:
+
+        @app.middleware("http")
+        async def profile_request(
+            request: Request,
+            call_next: Callable[[Request], Awaitable[Response]],
+        ):
+            if not request.query_params.get("profile", False):
+                return await call_next(request)
+            profiler = Profiler(
+                interval=config.profiling_interval_seconds,
+                async_mode="enabled",
+            )
+            profiler.start()
+            await call_next(request)
+            profiler.stop()
+            return HTMLResponse(profiler.output_html())
+
 
 pkgstore = config.get_package_store()
 

--- a/quetz/testing/fixtures.py
+++ b/quetz/testing/fixtures.py
@@ -182,7 +182,10 @@ enabled = {plugins}
 
 @pytest.fixture
 def config_extra():
-    return ""
+    return """
+[profiling]
+enable_sampling = true
+"""
 
 
 @pytest.fixture

--- a/quetz/tests/test_profiling.py
+++ b/quetz/tests/test_profiling.py
@@ -1,0 +1,4 @@
+def test_endpoint_profiling(client):
+    response = client.get("/health/ready/?profile=true")
+    assert response.status_code == 200
+    assert "text/html" in response.headers['Content-Type']


### PR DESCRIPTION
This PR leverages `pyinstrument` to provide sampling profiling to all endpoints exposed by `quetz`.

For this to happen, the `enable_sampling` configuration of the section `profiling` must be set to `True` and then adding`profiling=true` (or any value that evaluates to `True`) as a query parameter. Once this is done, the response will not be the expected one, but an HTML view of the profiling done by `pyinstrument`.