### PR TITLE
chore: move configurations to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = quetz/tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
           export QUETZ_IS_TEST=1
-          pytest -v ./quetz/tests/ --cov-config=.coveragerc --cov=. --cov-report=xml
+          pytest -v ./quetz/tests/ --cov-config=pyproject.toml --cov=. --cov-report=xml
 
       - name: Test the plugins
         shell: bash -l -eo pipefail {0}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include alembic.ini
 include dev_config.toml
 include environment.yml
 include init_db.py
-include .coveragerc
 include .flake8
 include .pre-commit-config.yaml
 include .readthedocs.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include .coveragerc
 include .flake8
 include .pre-commit-config.yaml
 include .readthedocs.yml
-include mypy.ini
 include download-test-package.sh
 
 recursive-include quetz/migrations *.*

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-plugins = sqlmypy
-disable_error_code=misc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,12 @@ reportUnboundVariable = true
 reportUndefinedVariable = false
 venv = ".venv"
 venvPath= "."
+
+[tool.mypy]
+ignore_missing_imports = true
+plugins = [
+  "sqlmypy"
+]
+disable_error_code = [
+  "misc"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,8 @@ plugins = [
 disable_error_code = [
   "misc"
 ]
+
+[tool.coverage.run]
+omit = [
+  "quetz/tests/*",
+]


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for the project. Instead of a separate `.coveragerc` and `mypy.ini`, we now would have all the configurations within the `pyproject.toml` file leading to a overall minimal code structure. 