### PR TITLE
Add async friendly upload

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
           - types-six
           - types-toml
           - types-ujson
+          - types-aiofiles
         args: [--show-error-codes]
   - repo: https://github.com/Quantco/pre-commit-mirrors-prettier
     rev: 2.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,7 @@ dependencies:
   - tenacity
   - xattr
   - aiofiles
+  - aioshutil
   - pyyaml
   - ujson
   - prometheus_client

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1388,7 +1388,7 @@ async def post_upload(
     dest = os.path.join(condainfo.info["subdir"], filename)
 
     body.seek(0)
-    pkgstore.add_package(body, channel_name, dest)
+    await pkgstore.add_package(body, channel_name, dest)
 
     package_name = str(condainfo.info.get("name"))
     package_data = rest_models.Package(

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1388,7 +1388,7 @@ async def post_upload(
     dest = os.path.join(condainfo.info["subdir"], filename)
 
     body.seek(0)
-    await pkgstore.add_package(body, channel_name, dest)
+    await pkgstore.add_package_async(body, channel_name, dest)
 
     package_name = str(condainfo.info.get("name"))
     package_data = rest_models.Package(

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -301,7 +301,9 @@ class S3Store(PackageStore):
         # to the s3fs constructor
         key = config['key'] if config['key'] != '' else None
         secret = config['secret'] if config['secret'] != '' else None
-        self.fs = s3fs.S3FileSystem(key=key, secret=secret, client_kwargs=client_kwargs)
+        self.fs = s3fs.S3FileSystem(
+            key=key, secret=secret, asynchronous=True, client_kwargs=client_kwargs
+        )
 
         self.bucket_prefix = config['bucket_prefix']
         self.bucket_suffix = config['bucket_suffix']
@@ -450,6 +452,7 @@ class AzureBlobStore(PackageStore):
             account_name=self.storage_account_name,
             connection_string=self.conn_string,
             account_key=self.access_key,
+            asynchronous=True,
         )
 
         self.container_prefix = config['container_prefix']

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -81,7 +81,7 @@ class PackageStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_package(self, package: File, channel: str, destination: str):
+    async def add_package(self, package: File, channel: str, destination: str):
         pass
 
     @abc.abstractmethod

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -81,7 +81,7 @@ class PackageStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def add_package(self, package: File, channel: str, destination: str):
+    def add_package(self, package: File, channel: str, destination: str):
         pass
 
     @abc.abstractmethod
@@ -171,7 +171,7 @@ class LocalStore(PackageStore):
         channel_path = path.join(self.channels_dir, name)
         self.fs.rm(channel_path, recursive=True)
 
-    async def add_package(self, package: File, channel: str, destination: str) -> None:
+    def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._atomic_open(channel, destination) as f:
             shutil.copyfileobj(package, f)
 

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -82,7 +82,7 @@ class PackageStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def add_package_async(self, package: File, channel: str, destination: str):
+    def add_package_async(self, package: File, channel: str, destination: str):
         pass
 
     @abc.abstractmethod
@@ -340,7 +340,7 @@ class S3Store(PackageStore):
         channel_path = self._bucket_map(name)
         self.fs.rm(channel_path, recursive=True, acl="private")
 
-    async def add_package(self, package: File, channel: str, destination: str) -> None:
+    def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._get_fs() as fs:
             bucket = self._bucket_map(channel)
             with fs.open(path.join(bucket, destination), "wb", acl="private") as pkg:
@@ -484,7 +484,7 @@ class AzureBlobStore(PackageStore):
         with self._get_fs() as fs:
             fs.rm(channel_path, recursive=True)
 
-    async def add_package(self, package: File, channel: str, destination: str) -> None:
+    def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._get_fs() as fs:
             container = self._container_map(channel)
             with fs.open(path.join(container, destination), "wb") as pkg:
@@ -638,7 +638,7 @@ class GoogleCloudStorageStore(PackageStore):
         with self._get_fs() as fs:
             fs.rm(channel_path, recursive=True)
 
-    async def add_package(self, package: File, channel: str, destination: str) -> None:
+    def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._get_fs() as fs:
             container = self._bucket_map(channel)
             with fs.open(path.join(container, destination), "wb") as pkg:

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -81,7 +81,7 @@ class PackageStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_package(self, package: File, channel: str, destination: str):
+    async def add_package(self, package: File, channel: str, destination: str):
         pass
 
     @abc.abstractmethod
@@ -171,7 +171,7 @@ class LocalStore(PackageStore):
         channel_path = path.join(self.channels_dir, name)
         self.fs.rm(channel_path, recursive=True)
 
-    def add_package(self, package: File, channel: str, destination: str) -> None:
+    async def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._atomic_open(channel, destination) as f:
             shutil.copyfileobj(package, f)
 

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -171,7 +171,7 @@ class LocalStore(PackageStore):
         channel_path = path.join(self.channels_dir, name)
         self.fs.rm(channel_path, recursive=True)
 
-    def add_package(self, package: File, channel: str, destination: str) -> None:
+    async def add_package(self, package: File, channel: str, destination: str) -> None:
         with self._atomic_open(channel, destination) as f:
             shutil.copyfileobj(package, f)
 

--- a/quetz/pkgstores.py
+++ b/quetz/pkgstores.py
@@ -355,7 +355,7 @@ class S3Store(PackageStore):
             bucket = self._bucket_map(channel)
             with fs.open(path.join(bucket, destination), "wb", acl="private") as pkg:
                 # use a chunk size of 10 Megabytes
-                aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
+                await aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
 
     def add_file(
         self, data: Union[str, bytes], channel: str, destination: StrPath
@@ -503,7 +503,7 @@ class AzureBlobStore(PackageStore):
             container = self._container_map(channel)
             with fs.open(path.join(container, destination), "wb") as pkg:
                 # use a chunk size of 10 Megabytes
-                aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
+                await aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
 
     def add_file(
         self, data: Union[str, bytes], channel: str, destination: StrPath
@@ -662,7 +662,7 @@ class GoogleCloudStorageStore(PackageStore):
             container = self._bucket_map(channel)
             with fs.open(path.join(container, destination), "wb") as pkg:
                 # use a chunk size of 10 Megabytes
-                aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
+                await aioshutil.copyfileobj(package, pkg, 10 * 1024 * 1024)
 
     def add_file(
         self, data: Union[str, bytes], channel: str, destination: StrPath

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -220,13 +220,13 @@ def test_store_add_list_files(any_store, channel, channel_name):
     assert type(metadata[1]) is float
     assert type(metadata[2]) is str
 
-
-def test_add_package(any_store, channel, channel_name):
+@pytest.mark.asyncio
+async def test_add_package(any_store, channel, channel_name):
     pkg_store = any_store
 
     data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
 
-    pkg_store.add_package(BytesIO(data), channel_name, "test-package-0.1-0.tar.gz")
+    await pkg_store.add_package(BytesIO(data), channel_name, "test-package-0.1-0.tar.gz")
 
     assert_files(pkg_store, channel_name, ["test-package-0.1-0.tar.gz"])
 

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -222,12 +222,24 @@ def test_store_add_list_files(any_store, channel, channel_name):
 
 
 @pytest.mark.asyncio
-async def test_add_package(any_store, channel, channel_name):
+async def test_add_package_async(any_store, channel, channel_name):
     pkg_store = any_store
 
     data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
 
     await pkg_store.add_package_async(
+        BytesIO(data), channel_name, "test-package-0.1-0.tar.gz"
+    )
+
+    assert_files(pkg_store, channel_name, ["test-package-0.1-0.tar.gz"])
+
+
+def test_add_package_async(any_store, channel, channel_name):
+    pkg_store = any_store
+
+    data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
+
+    pkg_store.add_package(
         BytesIO(data), channel_name, "test-package-0.1-0.tar.gz"
     )
 

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import time
 import uuid
+from pathlib import Path
+from io import BytesIO
 
 import pytest
 
@@ -209,6 +211,16 @@ def test_store_add_list_files(any_store, channel, channel_name):
     assert metadata[0] > 0
     assert type(metadata[1]) is float
     assert type(metadata[2]) is str
+
+
+def test_add_package(any_store, channel, channel_name):
+    pkg_store = any_store
+    
+    data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
+
+    pkg_store.add_package(BytesIO(data), channel_name, "test-package-0.1-0.tar.gz")
+
+    assert pkg_store.list_files(channel_name) == ["test-package-0.1-0.tar.gz"]
 
 
 def test_move_file(any_store, channel, channel_name):

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -234,14 +234,12 @@ async def test_add_package_async(any_store, channel, channel_name):
     assert_files(pkg_store, channel_name, ["test-package-0.1-0.tar.gz"])
 
 
-def test_add_package_async(any_store, channel, channel_name):
+def test_add_package(any_store, channel, channel_name):
     pkg_store = any_store
 
     data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
 
-    pkg_store.add_package(
-        BytesIO(data), channel_name, "test-package-0.1-0.tar.gz"
-    )
+    pkg_store.add_package(BytesIO(data), channel_name, "test-package-0.1-0.tar.gz")
 
     assert_files(pkg_store, channel_name, ["test-package-0.1-0.tar.gz"])
 

--- a/quetz/tests/test_pkg_stores.py
+++ b/quetz/tests/test_pkg_stores.py
@@ -220,13 +220,16 @@ def test_store_add_list_files(any_store, channel, channel_name):
     assert type(metadata[1]) is float
     assert type(metadata[2]) is str
 
+
 @pytest.mark.asyncio
 async def test_add_package(any_store, channel, channel_name):
     pkg_store = any_store
 
     data = (Path(__file__).parent / "data" / "test-package-0.1-0.tar.bz2").read_bytes()
 
-    await pkg_store.add_package(BytesIO(data), channel_name, "test-package-0.1-0.tar.gz")
+    await pkg_store.add_package_async(
+        BytesIO(data), channel_name, "test-package-0.1-0.tar.gz"
+    )
 
     assert_files(pkg_store, channel_name, ["test-package-0.1-0.tar.gz"])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
   ujson
   uvicorn
   zstandard
+  aioshutil
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Still a work in progress, but should be working in the local package store.

the `add_package` was not directly tested, only the `add_files`, but the upload doesn't use the `add_files`. Thus I added a very minimal test for `add_package` (with a bonus refactoring) and then went to turn it into an asynchronous function. `aiofiles` was already part of the dependencies but was never used until now, which provides a facade of synchronicity for FS local operations.

We can discuss some decisions, but first I wanted to make it work. Instead of saving the uploaded file with a random name and then renaming it, I'm writing it directly with the correct name. I tried the other way but didn't manage. Could give it another try if it's really critical.

Anyhow, would appreciate early feedback.

Edit:

I did end up keeping the original `add_package` because it's used in other areas and don't want to pollute the codebase with async/await keywords. Thus, added a separate async version for `add_package`. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204438786781707