### PR TITLE
add: osx-arm64 version for testing on newer apple devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ To run the upload, you need to set environment variables for the quetz API key (
 ```bash
 export QUETZ_API_KEY=E_KaBFstCKI9hTdPM7DQq56GglRHf2HW7tQtq6si370
 export QUETZ_SERVER_URL=http://localhost:8000
-quetz-client post_file_to_channel channel0 xtensor/linux-64/xtensor-0.16.1-0.tar.bz2
-quetz-client post_file_to_channel channel0 xtensor/osx-64/xtensor-0.16.1-0.tar.bz2
+quetz-client post_file_to_channel channel0 xtensor/linux-64/xtensor-0.24.3-h924138e_1.tar.bz2
+quetz-client post_file_to_channel channel0 xtensor/osx-64/xtensor-0.24.3-h1b54a9f_1.tar.bz2
+quetz-client post_file_to_channel channel0 xtensor/osx-arm64/xtensor-0.24.3-hf86a087_1.tar.bz2
 ```
 
 Install the test package with conda:

--- a/download-test-package.sh
+++ b/download-test-package.sh
@@ -2,5 +2,7 @@
 
 mkdir -p xtensor/osx-64
 mkdir -p xtensor/linux-64
-wget https://conda.anaconda.org/conda-forge/osx-64/xtensor-0.16.1-0.tar.bz2 -P xtensor/osx-64/
-wget https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.16.1-0.tar.bz2 -P xtensor/linux-64/
+mkdir -p xtensor/osx-arm64
+wget https://conda.anaconda.org/conda-forge/osx-64/xtensor-0.24.3-h1b54a9f_1.tar.bz2 -P xtensor/osx-64/
+wget https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.24.3-h924138e_1.tar.bz2 -P xtensor/linux-64/
+wget https://conda.anaconda.org/conda-forge/osx-arm64/xtensor-0.24.3-hf86a087_1.tar.bz2 -P xtensor/osx-arm64/


### PR DESCRIPTION
Hey,
while checking out the development instructions for setting up a new server I realized that this command
```shell
mamba install --strict-channel-priority -c http://localhost:8000/get/channel0 -c conda-forge xtensor
```
does not work on Apple Silicon devices, since no xtensor is being downloaded.
I added an osx-arm64 version and updated the versions somewhat.

Thanks!