### PR TITLE
enhancement: Make sqlalchemy pool settings configurable

### DIFF
--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -19,9 +19,32 @@ Quetz can be run with SQLlite or PostgreSQL as database backends (PostgreSQL is 
 .. code::
 
    [sqlalchemy]
+   # The URL to the data base to use.
    database_url = "postgresql://postgres:mysecretpassword@localhost:5432/quetz"
 
+   # Undocumented setting, unknown use
+   database_plugin_path = ""
+
+   # Passed directly to the "echo" argument of sqlalchemy.create_engine
+   echo_sql = false
+
+   # The pool size for sqlalchemy engine connections to postgres DBs
+   # see https://docs.sqlalchemy.org/en/latest/core/pooling.html
+   postgres_pool_size = 100
+
+   # The maximal number of overflow connections beyond the pool size
+   # see https://docs.sqlalchemy.org/en/latest/core/pooling.html
+   postgres_max_overflow = 100
+
 :database_url: URL of the database (may contain user credentials) prefixed with either ``sqlite://`` or ``postgresql://``.
+
+:database_plugin_path: Undocumented setting, unknown use, default: `""`.
+
+:echo_sql: Passed directly to the "echo" argument of sqlalchemy.create_engine, default: `false`.
+
+:postgres_pool_size: The pool size for sqlalchemy engine connections to postgres DBs. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_. Default: `100`
+
+:postgres_max_overflow: The maximal number of overflow connections beyond the pool size. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_. Default: `100`
 
 ``github`` section
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -19,7 +19,7 @@ Quetz can be run with SQLlite or PostgreSQL as database backends (PostgreSQL is 
 .. code::
 
    [sqlalchemy]
-   # The URL to the data base to use.
+   # The URL to the database to use.
    database_url = "postgresql://postgres:mysecretpassword@localhost:5432/quetz"
 
    # Undocumented setting, unknown use

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -106,6 +106,8 @@ class Config:
                 ConfigEntry("database_url", str),
                 ConfigEntry("database_plugin_path", str, default="", required=False),
                 ConfigEntry("echo_sql", bool, default=False, required=False),
+                ConfigEntry("postgres_pool_size", int, default=100, required=False),
+                ConfigEntry("postgres_max_overflow", int, default=100, required=False),
             ],
         ),
         ConfigSection(

--- a/quetz/database.py
+++ b/quetz/database.py
@@ -76,8 +76,8 @@ def get_db_manager():
     db = get_session(
         db_url=config.sqlalchemy_database_url,
         echo=config.sqlalchemy_echo_sql,
-        pool_size=config.sqlalchemy_pool_size,
-        max_overflow=config.sqlalchemy_max_overflow,
+        pool_size=config.sqlalchemy_postgres_pool_size,
+        max_overflow=config.sqlalchemy_postgres_max_overflow,
     )
 
     try:

--- a/quetz/database.py
+++ b/quetz/database.py
@@ -27,6 +27,8 @@ def set_metrics(*args):
 
 
 def get_engine(db_url, echo: bool = False, reuse_engine=True, **kwargs) -> Engine:
+    config = Config()
+
     if db_url.startswith('sqlite'):
         kwargs.setdefault('connect_args', {'check_same_thread': False})
 
@@ -38,10 +40,13 @@ def get_engine(db_url, echo: bool = False, reuse_engine=True, **kwargs) -> Engin
     global engine
 
     if not engine or not reuse_engine:
-        # TODO make configurable!
         if db_url.startswith('postgres'):
             engine = create_engine(
-                db_url, echo=echo, pool_size=200, max_overflow=100, **kwargs
+                db_url,
+                echo=echo,
+                pool_size=config.sqlalchemy_postgres_pool_size,
+                max_overflow=config.sqlalchemy.sqlalchemy_postgres_max_overflow,
+                **kwargs
             )
             for event_name in ['connect', 'close', 'checkin', 'checkout']:
                 event.listen(engine, event_name, set_metrics)


### PR DESCRIPTION
This PR adds configuration settings for the sqlalchemy pool size and overflow settings.

Additionally, the docs for the sqlalchemy configuration section are extended. While doing that, I realized that there is a setting `database_plugin_path`, which afaict [is unused](https://github.com/search?q=repo%3Amamba-org%2Fquetz+database_plugin_path&type=code). I have not removed it for now, but if anyone knows what it's about, let me know.