### PR TITLE
Do not pass pooling arguments to sqlite

### DIFF
--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -30,10 +30,12 @@ Quetz can be run with SQLlite or PostgreSQL as database backends (PostgreSQL is 
 
    # The pool size for sqlalchemy engine connections to postgres DBs
    # see https://docs.sqlalchemy.org/en/latest/core/pooling.html
-   postgres_pool_size = 100
+   # Ignored for sqlite data bases
+   postgres_pool_size = 10
 
    # The maximal number of overflow connections beyond the pool size
    # see https://docs.sqlalchemy.org/en/latest/core/pooling.html
+   # Ignored for sqlite data bases
    postgres_max_overflow = 100
 
 :database_url: URL of the database (may contain user credentials) prefixed with either ``sqlite://`` or ``postgresql://``.
@@ -42,9 +44,9 @@ Quetz can be run with SQLlite or PostgreSQL as database backends (PostgreSQL is 
 
 :echo_sql: Passed directly to the "echo" argument of sqlalchemy.create_engine, default: `false`.
 
-:postgres_pool_size: The pool size for sqlalchemy engine connections to postgres DBs. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_. Default: `100`
+:postgres_pool_size: The pool size for sqlalchemy engine connections to postgres DBs. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_. Ignored for sqlite data bases. Default: `10`
 
-:postgres_max_overflow: The maximal number of overflow connections beyond the pool size. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_. Default: `100`
+:postgres_max_overflow: The maximal number of overflow connections beyond the pool size. See `sqlalchemy docs <https://docs.sqlalchemy.org/en/latest/core/pooling.html>`_.  Ignored for sqlite data bases. Default: `100`
 
 ``github`` section
 ^^^^^^^^^^^^^^^^^^

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -106,7 +106,7 @@ class Config:
                 ConfigEntry("database_url", str),
                 ConfigEntry("database_plugin_path", str, default="", required=False),
                 ConfigEntry("echo_sql", bool, default=False, required=False),
-                ConfigEntry("postgres_pool_size", int, default=100, required=False),
+                ConfigEntry("postgres_pool_size", int, default=10, required=False),
                 ConfigEntry("postgres_max_overflow", int, default=100, required=False),
             ],
         ),


### PR DESCRIPTION
* Pooling arguments in #632 were erroneously also propagated to sqlite engines. They should only be used if a postgres backend is used. This PR changes the propagation to fix that.
* I also reduced the default pool size from `100` to `10`, which should be much more appropriate for the typical quetz use cases, where there is no reason to maintain 100 open connections

Closes #640 