### PR TITLE
Bump pyright-python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
     hooks:
       - id: prettier-conda
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.294
+    rev: v1.1.314
     hooks:
       - id: pyright

--- a/quetz/authentication/oauth2.py
+++ b/quetz/authentication/oauth2.py
@@ -85,6 +85,7 @@ class OAuthAuthenticator(BaseAuthenticator):
 
     def __init__(self, config: Config, client_kwargs=None, provider=None, app=None):
         super().__init__(config, provider, app)
+        self.client: OAuthAuthenticator
         if self.is_enabled:
             self.register(client_kwargs=client_kwargs)
 

--- a/quetz/tests/authentification/test_oauth.py
+++ b/quetz/tests/authentification/test_oauth.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 
 import pytest
@@ -222,6 +223,9 @@ mD1rl6xev7GRoqUYdKYdt9NJyDGEULZ6NbIWyXo3kTp7HdQLRn0BJg==
 """
 
 
+@pytest.mark.skipif(
+    not hasattr(hashlib, "RS256"), reason="hashlib does not support RS256"
+)
 @pytest.fixture
 def google_response(login):
     google_client_id = 'aaa'
@@ -233,12 +237,14 @@ def google_response(login):
         "name": "monalisa",
     }
     access_token = "b"
+    half_hash = create_half_hash(access_token, "RS256")
+    assert half_hash is not None
     payload = {
         "iss": "https://accounts.google.com",
         "azp": google_client_id,
         "aud": "1234987819200.apps.googleusercontent.com",
         "sub": login + "_id",
-        "at_hash": create_half_hash(access_token, "RS256").decode("ascii"),
+        "at_hash": half_hash.decode("ascii"),
         "hd": "example.com",
         "email": login,
         "email_verified": "true",


### PR DESCRIPTION
On my machine (openSUSE Tumbleweed) `pre-commit` creates dozens of
`npm` and `pyright` processes and linting never finishes.

The latest version of `pyright-python` does not have this issue.
