### PR TITLE
Fix crash when uploading a package through scoped API key

### DIFF
--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -39,19 +39,29 @@ class Rules:
         self.session = session
         self.db = db
 
+    def get_valid_api_key(self) -> Optional[ApiKey]:
+        if not self.API_key:
+            return None
+        return (
+            self.db.query(ApiKey)
+            .filter(ApiKey.key == self.API_key, ~ApiKey.deleted)
+            .filter(
+                ApiKey.key == self.API_key,
+                or_(ApiKey.expire_at >= date.today(), ApiKey.expire_at.is_(None)),
+            )
+            .one_or_none()
+        )
+
     def get_owner(self) -> Optional[bytes]:
+        """
+        gets the id of the owner of the authenticated session, if any. Either:
+          a) the owner of the API key that is used for authentication
+          b) the user_id of the encrypted session cookie
+        """
         owner_id = None
 
         if self.API_key:
-            api_key = (
-                self.db.query(ApiKey)
-                .filter(ApiKey.key == self.API_key, ~ApiKey.deleted)
-                .filter(
-                    ApiKey.key == self.API_key,
-                    or_(ApiKey.expire_at >= date.today(), ApiKey.expire_at.is_(None)),
-                )
-                .one_or_none()
-            )
+            api_key = self.get_valid_api_key()
             if api_key:
                 owner_id = api_key.owner_id
         else:
@@ -61,19 +71,27 @@ class Rules:
 
         return owner_id
 
+    def assert_owner(self) -> bytes:
+        owner_id = self.get_owner()
+
+        if not owner_id or not self.db.query(User).filter(User.id == owner_id).count():
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not logged in",
+            )
+
+        return owner_id
+
     def get_user(self) -> Optional[bytes]:
+        """
+        gets the id of the user of the authenticated session, if any. Either:
+          a) the user_id of the API key (not its owner!) that is used for authentication
+          b) the user_id of the encrypted session cookie
+        """
         user_id = None
 
         if self.API_key:
-            api_key = (
-                self.db.query(ApiKey)
-                .filter(ApiKey.key == self.API_key, ~ApiKey.deleted)
-                .filter(
-                    ApiKey.key == self.API_key,
-                    or_(ApiKey.expire_at >= date.today(), ApiKey.expire_at.is_(None)),
-                )
-                .one_or_none()
-            )
+            api_key = self.get_valid_api_key()
             if api_key:
                 user_id = api_key.user_id
         else:

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -39,6 +39,28 @@ class Rules:
         self.session = session
         self.db = db
 
+    def get_owner(self) -> Optional[bytes]:
+        owner_id = None
+
+        if self.API_key:
+            api_key = (
+                self.db.query(ApiKey)
+                .filter(ApiKey.key == self.API_key, ~ApiKey.deleted)
+                .filter(
+                    ApiKey.key == self.API_key,
+                    or_(ApiKey.expire_at >= date.today(), ApiKey.expire_at.is_(None)),
+                )
+                .one_or_none()
+            )
+            if api_key:
+                owner_id = api_key.owner_id
+        else:
+            user_id = self.session.get("user_id")
+            if user_id:
+                owner_id = uuid.UUID(user_id).bytes
+
+        return owner_id
+
     def get_user(self) -> Optional[bytes]:
         user_id = None
 


### PR DESCRIPTION
fixes #642 

## Problem

- the uploader_id gets set to the user_id of the uploader when uploading package files
  - in case a scoped API key is used, that user_id points to an "anonymous user"
- when listing packages, that anonymous user does not have a name (null) and provokes a crash

## Solution

- when uploading through an API key, always retrieve the owner_id and use that as uploader_id

