### PR TITLE
Checkout source code from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           - 6379:6379
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: write gcs token file
         run: |
           mkdir $(dirname "${GCS_TOKEN}")


### PR DESCRIPTION
In https://github.com/mamba-org/quetz/pull/636 we introduced a bug. The CI trigger `pull_request_target` runs in the context of the target repository. This means the standard checkout action uses the target repository, which breaks CI for contributions from forks.

More information on this issue here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Just so you know, the article strongly advises against the fix I've implemented here, as it opens the door for potential pwn requests. However, we require maintainer approval for first-time contributors before running CI, so we at least have some safe guard.

Update: I've just enabled a required maintainer approval for all outside contributros.
