### PR TITLE
Remove DB dependency for health endpoint

### DIFF
--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1863,8 +1863,8 @@ def serve_channel_index(
 
 @app.get("/health/ready", status_code=status.HTTP_200_OK)
 @app.get("/health/live", status_code=status.HTTP_200_OK)
-def is_ready_live(task: Task = Depends(get_tasks_worker)):
-    return {}
+def is_ready_live():
+    return {"component": "http-server", "status": "ok"}
 
 
 frontend.register(app)


### PR DESCRIPTION
The most basic health check route should reflect the operational status of the http server itself and therefore not depend on any DB objects. If we want to expose a health metric that reflects our ability to contact the DB or other outside dependencies, we should add additional routes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204808460281389