### PR TITLE
Pin pydantic<2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,5 +50,6 @@ dependencies:
   - conda-content-trust
   - pyinstrument
   - pytest-asyncio
+  - pydantic <2
   - pip:
       - git+https://github.com/jupyter-server/jupyter_releaser.git@v2


### PR DESCRIPTION
Two issues:
1. pydantic was not in our environment.yml even though we are using it directly (not just as a transitive dependency)
2. our code is currently not compatible with the recently released pydantic 2.

This PR hotfixes the dependency by down pinning it. As a follow up, we should migrate our code to be compatible with pydantic 2 in the future.