### PR TITLE
Add migration script for scoped API keys

### DIFF
--- a/quetz/migrations/versions/3ba25f23fb7d_update_scoped_api_key_uploader_id.py
+++ b/quetz/migrations/versions/3ba25f23fb7d_update_scoped_api_key_uploader_id.py
@@ -1,0 +1,57 @@
+"""Update scoped API key uploader id
+
+Revision ID: 3ba25f23fb7d
+Revises: d212023a8e0b
+Create Date: 2023-08-02 08:03:09.961559
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '3ba25f23fb7d'
+down_revision = 'd212023a8e0b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    package_versions = sa.sql.table("package_versions", sa.sql.column("uploader_id"))
+    conn = op.get_bind()
+    # Get all user_id/owner_id from channel scoped API keys
+    # (user is anonymous - username is null)
+    res = conn.execute(
+        """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
+            INNER JOIN users ON users.id = api_keys.user_id
+            WHERE users.username is NULL;
+            """
+    )
+    results = res.fetchall()
+    # Replace the uploader with the key owner (real user instead of the anonymous one)
+    for result in results:
+        op.execute(
+            package_versions.update()
+            .where(package_versions.c.uploader_id == result[0])
+            .values(uploader_id=result[1])
+        )
+
+
+def downgrade():
+    package_versions = sa.sql.table("package_versions", sa.sql.column("uploader_id"))
+    conn = op.get_bind()
+    # Get all user_id/owner_id from channel scoped API keys
+    # (user is anonymous - username is null)
+    res = conn.execute(
+        """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
+            INNER JOIN users ON users.id = api_keys.user_id
+            WHERE users.username is NULL;
+            """
+    )
+    results = res.fetchall()
+    # Replace the uploader with the key anonymous user
+    for result in results:
+        op.execute(
+            package_versions.update()
+            .where(package_versions.c.uploader_id == result[1])
+            .values(uploader_id=result[0])
+        )

--- a/quetz/migrations/versions/3ba25f23fb7d_update_scoped_api_key_uploader_id.py
+++ b/quetz/migrations/versions/3ba25f23fb7d_update_scoped_api_key_uploader_id.py
@@ -21,10 +21,12 @@ def upgrade():
     # Get all user_id/owner_id from channel scoped API keys
     # (user is anonymous - username is null)
     res = conn.execute(
-        """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
+        sa.text(
+            """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
             INNER JOIN users ON users.id = api_keys.user_id
             WHERE users.username is NULL;
             """
+        )
     )
     results = res.fetchall()
     # Replace the uploader with the key owner (real user instead of the anonymous one)
@@ -42,10 +44,12 @@ def downgrade():
     # Get all user_id/owner_id from channel scoped API keys
     # (user is anonymous - username is null)
     res = conn.execute(
-        """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
+        sa.text(
+            """SELECT api_keys.user_id, api_keys.owner_id FROM api_keys
             INNER JOIN users ON users.id = api_keys.user_id
             WHERE users.username is NULL;
             """
+        )
     )
     results = res.fetchall()
     # Replace the uploader with the key anonymous user


### PR DESCRIPTION
Add script to update `package_versions` uploader with API keys owner instead of the key anonymous user.

This is linked to https://github.com/mamba-org/quetz/issues/642 fixed in https://github.com/mamba-org/quetz/pull/647.
The script allows users to update existing databases automatically.