### PR TITLE
Migrate to Pydantic v2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,6 +50,6 @@ dependencies:
   - conda-content-trust
   - pyinstrument
   - pytest-asyncio
-  - pydantic <2
+  - pydantic >=2
   - pip:
       - git+https://github.com/jupyter-server/jupyter_releaser.git@v2

--- a/quetz/db_models.py
+++ b/quetz/db_models.py
@@ -55,7 +55,7 @@ class User(Base):
         'Profile', uselist=False, back_populates='user', cascade="all,delete-orphan"
     )
 
-    role = Column(String)
+    role = Column(String, nullable=True)
 
     @classmethod
     def find(cls, db, name):

--- a/quetz/jobs/api.py
+++ b/quetz/jobs/api.py
@@ -17,7 +17,7 @@ from quetz.jobs import models as job_db_models
 from quetz.rest_models import PaginatedResponse
 
 from .models import JobStatus, TaskStatus
-from .rest_models import Job, JobBase, JobUpdateModel, Task
+from .rest_models import Job, JobCreate, JobUpdateModel, Task
 
 api_router = APIRouter()
 
@@ -44,7 +44,7 @@ def get_jobs(
 
 @api_router.post("/api/jobs", tags=["Jobs"], status_code=201, response_model=Job)
 def create_job(
-    job: JobBase,
+    job: JobCreate,
     dao: Dao = Depends(get_dao),
     auth: authorization.Rules = Depends(get_rules),
 ):

--- a/quetz/jobs/rest_models.py
+++ b/quetz/jobs/rest_models.py
@@ -83,7 +83,6 @@ def parse_job_name(v):
 class JobBase(BaseModel):
     """New job spec"""
 
-    items_spec: str = Field(..., title='Item selector spec')
     manifest: str = Field(None, title='Name of the function')
 
     start_at: Optional[datetime] = Field(
@@ -108,6 +107,12 @@ class JobBase(BaseModel):
         return function_name.encode('ascii')
 
 
+class JobCreate(JobBase):
+    """Create job spec"""
+
+    items_spec: str = Field(..., title='Item selector spec')
+
+
 class JobUpdateModel(BaseModel):
     """Modify job spec items (status and items_spec)"""
 
@@ -124,7 +129,7 @@ class Job(JobBase):
 
     status: JobStatus = Field(None, title='Status of the job (running, paused, ...)')
 
-    items_spec: str = Field(None, title='Item selector spec')
+    items_spec: Optional[str] = Field(None, title='Item selector spec')
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -1064,7 +1064,7 @@ def get_package_versions(
     version_list = []
 
     for version, profile, api_key_profile in version_profile_list:
-        version_data = rest_models.PackageVersion.from_orm(version)
+        version_data = rest_models.PackageVersion.model_validate(version)
         version_list.append(version_data)
 
     return version_list
@@ -1089,7 +1089,7 @@ def get_paginated_package_versions(
     version_list = []
 
     for version, profile, api_key_profile in version_profile_list['result']:
-        version_data = rest_models.PackageVersion.from_orm(version)
+        version_data = rest_models.PackageVersion.model_validate(version)
         version_list.append(version_data)
 
     return {

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -17,7 +17,6 @@ from tempfile import SpooledTemporaryFile, TemporaryFile
 from typing import Awaitable, Callable, List, Optional, Tuple, Type
 
 import pydantic
-import pydantic.error_wrappers
 import requests
 from fastapi import (
     APIRouter,
@@ -1643,7 +1642,7 @@ def handle_package_files(
                     summary=str(condainfo.about.get("summary", "n/a")),
                     description=str(condainfo.about.get("description", "n/a")),
                 )
-            except pydantic.error_wrappers.ValidationError as err:
+            except pydantic.ValidationError as err:
                 _delete_file(condainfo, file.filename)
                 raise errors.ValidationError(
                     "Validation Error for package: "

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -732,7 +732,7 @@ def post_channel(
             detail="Cannot use both `includelist` and `excludelist` together.",
         )
 
-    user_attrs = new_channel.dict(exclude_unset=True)
+    user_attrs = new_channel.model_dump(exclude_unset=True)
 
     if "size_limit" in user_attrs:
         auth.assert_set_channel_size_limit()
@@ -789,7 +789,7 @@ def patch_channel(
 ):
     auth.assert_update_channel_info(channel.name)
 
-    user_attrs = channel_data.dict(exclude_unset=True)
+    user_attrs = channel_data.model_dump(exclude_unset=True)
 
     if "size_limit" in user_attrs:
         auth.assert_set_channel_size_limit()

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -477,7 +477,7 @@ def delete_user(
 
 @api_router.get(
     "/users/{username}/role",
-    response_model=rest_models.UserRole,
+    response_model=rest_models.UserOptionalRole,
     tags=["users"],
 )
 def get_user_role(

--- a/quetz/metrics/rest_models.py
+++ b/quetz/metrics/rest_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from quetz.metrics.db_models import IntervalType
 
@@ -9,9 +9,7 @@ from quetz.metrics.db_models import IntervalType
 class PackageVersionMetricItem(BaseModel):
     timestamp: datetime
     count: int
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PackageVersionMetricSeries(BaseModel):

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -134,7 +134,7 @@ class ChannelMetadata(BaseModel):
 
 class Channel(ChannelBase):
     metadata: ChannelMetadata = Field(
-        default_factory=ChannelMetadata, title="channel metadata", example={}
+        default_factory=ChannelMetadata, title="channel metadata", examples={}
     )
 
     actions: Optional[List[ChannelActionEnum]] = Field(

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -15,7 +15,7 @@ T = TypeVar('T')
 
 
 class BaseProfile(BaseModel):
-    name: Optional[str] = Field(None, nullable=True)
+    name: Optional[str] = Field(None)
     avatar_url: str
     model_config = ConfigDict(from_attributes=True)
 
@@ -60,17 +60,13 @@ class MirrorMode(str, Enum):
 class ChannelBase(BaseModel):
     name: str = Field(None, title='The name of the channel', max_length=50)
     description: Optional[str] = Field(
-        None, title='The description of the channel', max_length=300, nullable=True
+        None, title='The description of the channel', max_length=300
     )
     private: bool = Field(True, title="channel should be private")
-    size_limit: Optional[int] = Field(
-        None, title="size limit of the channel", nullable=True
-    )
+    size_limit: Optional[int] = Field(None, title="size limit of the channel")
     ttl: int = Field(36000, title="ttl of the channel")
-    mirror_channel_url: Optional[str] = Field(
-        None, pattern="^(http|https)://.+", nullable=True
-    )
-    mirror_mode: Optional[MirrorMode] = Field(None, nullable=True)
+    mirror_channel_url: Optional[str] = Field(None, pattern="^(http|https)://.+")
+    mirror_mode: Optional[MirrorMode] = Field(None)
 
     @field_validator("size_limit")
     @classmethod
@@ -124,18 +120,15 @@ class ChannelMetadata(BaseModel):
     includelist: Optional[List[str]] = Field(
         None,
         title="list of packages to include while creating a channel",
-        nullable=True,
     )
     excludelist: Optional[List[str]] = Field(
         None,
         title="list of packages to exclude while creating a channel",
-        nullable=True,
     )
     proxylist: Optional[List[str]] = Field(
         None,
         title="list of packages that should only be proxied (not copied, "
         "stored and redistributed)",
-        nullable=True,
     )
 
 
@@ -148,7 +141,6 @@ class Channel(ChannelBase):
         None,
         title="list of actions to run after channel creation "
         "(see /channels/{}/actions for description)",
-        nullable=True,
     )
 
     @model_validator(mode='after')
@@ -170,12 +162,8 @@ class Channel(ChannelBase):
 
 class ChannelMirrorBase(BaseModel):
     url: str = Field(None, pattern="^(http|https)://.+")
-    api_endpoint: Optional[str] = Field(
-        None, pattern="^(http|https)://.+", nullable=True
-    )
-    metrics_endpoint: Optional[str] = Field(
-        None, pattern="^(http|https)://.+", nullable=True
-    )
+    api_endpoint: Optional[str] = Field(None, pattern="^(http|https)://.+")
+    metrics_endpoint: Optional[str] = Field(None, pattern="^(http|https)://.+")
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -187,22 +175,12 @@ class Package(BaseModel):
     name: str = Field(
         None, title='The name of package', max_length=1500, pattern=r'^[a-z0-9-_\.]*$'
     )
-    summary: Optional[str] = Field(
-        None, title='The summary of the package', nullable=True
-    )
-    description: Optional[str] = Field(
-        None, title='The description of the package', nullable=True
-    )
-    url: Optional[str] = Field(None, title="project url", nullable=True)
-    platforms: Optional[List[str]] = Field(
-        None, title="supported platforms", nullable=True
-    )
-    current_version: Optional[str] = Field(
-        None, title="latest version of any platform", nullable=True
-    )
-    latest_change: Optional[datetime] = Field(
-        None, title="date of latest change", nullable=True
-    )
+    summary: Optional[str] = Field(None, title='The summary of the package')
+    description: Optional[str] = Field(None, title='The description of the package')
+    url: Optional[str] = Field(None, title="project url")
+    platforms: Optional[List[str]] = Field(None, title="supported platforms")
+    current_version: Optional[str] = Field(None, title="latest version of any platform")
+    latest_change: Optional[datetime] = Field(None, title="date of latest change")
 
     @field_validator("platforms", mode="before")
     @classmethod
@@ -228,9 +206,7 @@ class PackageSearch(Package):
 
 class ChannelSearch(BaseModel):
     name: str = Field(None, title='The name of the channel', max_length=1500)
-    description: Optional[str] = Field(
-        None, title='The description of the channel', nullable=True
-    )
+    description: Optional[str] = Field(None, title='The description of the channel')
     private: bool = Field(None, title='The visibility of the channel')
     model_config = ConfigDict(from_attributes=True)
 
@@ -255,15 +231,15 @@ class UserRole(BaseModel):
 
 class CPRole(BaseModel):
     channel: str
-    package: Optional[str] = Field(None, nullable=True)
+    package: Optional[str] = Field(None)
     role: str = Role
 
 
 class BaseApiKey(BaseModel):
     description: str
-    time_created: Optional[date] = Field(None, nullable=True)
-    expire_at: Optional[date] = Field(None, nullable=True)
-    roles: Optional[List[CPRole]] = Field(None, nullable=True)
+    time_created: Optional[date] = Field(None)
+    expire_at: Optional[date] = Field(None)
+    roles: Optional[List[CPRole]] = Field(None)
 
 
 class ApiKey(BaseApiKey):
@@ -305,5 +281,5 @@ class PackageVersion(BaseModel):
 
 class ChannelAction(BaseModel):
     action: ChannelActionEnum
-    start_at: Optional[datetime] = Field(None, nullable=True)
-    repeat_every_seconds: Optional[int] = Field(None, nullable=True)
+    start_at: Optional[datetime] = Field(None)
+    repeat_every_seconds: Optional[int] = Field(None)

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -194,7 +194,9 @@ class Package(BaseModel):
         None, title='The description of the package', nullable=True
     )
     url: Optional[str] = Field(None, title="project url", nullable=True)
-    platforms: List[str] = Field(None, title="supported platforms", nullable=True)
+    platforms: Optional[List[str]] = Field(
+        None, title="supported platforms", nullable=True
+    )
     current_version: Optional[str] = Field(
         None, title="latest version of any platform", nullable=True
     )
@@ -226,7 +228,9 @@ class PackageSearch(Package):
 
 class ChannelSearch(BaseModel):
     name: str = Field(None, title='The name of the channel', max_length=1500)
-    description: str = Field(None, title='The description of the channel')
+    description: Optional[str] = Field(
+        None, title='The description of the channel', nullable=True
+    )
     private: bool = Field(None, title='The visibility of the channel')
     model_config = ConfigDict(from_attributes=True)
 

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -34,7 +34,7 @@ class User(BaseUser):
     profile: BaseProfile
 
 
-Profile.update_forward_refs()
+Profile.model_rebuild()
 
 
 Role = Field(None, pattern='owner|maintainer|member')

--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -245,6 +245,10 @@ class PostMember(BaseModel):
     role: str = Role
 
 
+class UserOptionalRole(BaseModel):
+    role: Optional[str] = Role
+
+
 class UserRole(BaseModel):
     role: str = Role
 

--- a/quetz/tests/api/test_api_keys.py
+++ b/quetz/tests/api/test_api_keys.py
@@ -11,7 +11,7 @@ def api_keys(other_user, user, db, dao: Dao):
     def key_factory(key_user, descr, expire_at, roles):
         return dao.create_api_key(
             key_user.id,
-            BaseApiKey.parse_obj(
+            BaseApiKey.model_validate(
                 dict(description=descr, expire_at=expire_at, roles=roles)
             ),
             descr,
@@ -111,7 +111,7 @@ def test_list_keys_with_package_roles(
 def test_list_keys_subrole(auth_client, dao, user, private_channel):
     dao.create_api_key(
         user.id,
-        BaseApiKey.parse_obj(
+        BaseApiKey.model_validate(
             dict(
                 description="user-key",
                 roles=[
@@ -134,7 +134,7 @@ def test_list_keys_subrole(auth_client, dao, user, private_channel):
 def test_list_keys_without_roles(auth_client, dao, user):
     dao.create_api_key(
         user.id,
-        BaseApiKey.parse_obj(dict(description="user-key", roles=[])),
+        BaseApiKey.model_validate(dict(description="user-key", roles=[])),
         "user-key",
     )
 

--- a/quetz/tests/api/test_channels.py
+++ b/quetz/tests/api/test_channels.py
@@ -689,7 +689,7 @@ def test_url_with_slash(auth_client, public_channel, db, remote_session):
     response = auth_client.post(
         f"/api/channels/{public_channel.name}/mirrors/",
         json={"url": mirror_url},
-        allow_redirects=False,
+        follow_redirects=False,
     )
 
     assert response.status_code == 307

--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -550,7 +550,7 @@ def test_validate_package_names(auth_client, public_channel, remove_package_vers
 @pytest.mark.parametrize(
     "package_name,msg",
     [
-        ("TestPackage", "string does not match"),
+        ("TestPackage", "String should match"),
         ("test-package", None),
     ],
 )

--- a/quetz/tests/api/test_main_packages.py
+++ b/quetz/tests/api/test_main_packages.py
@@ -776,7 +776,7 @@ def api_key(db, dao: Dao, owner, private_channel):
     # create an api key with restriction
     key = dao.create_api_key(
         owner.id,
-        BaseApiKey.parse_obj(
+        BaseApiKey.model_validate(
             dict(
                 description="test api key",
                 expire_at="2099-12-31",

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -607,7 +607,7 @@ def test_post_new_job_invalid_items_spec(auth_client, user, db, dummy_job_plugin
     )
     assert response.status_code == 422
     msg = response.json()['detail']
-    assert "not an allowed value" in msg[0]['msg']
+    assert "Input should be a valid string" in msg[0]['msg']
 
 
 @pytest.mark.parametrize("user_role", ["owner"])

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -598,10 +598,14 @@ def test_post_new_job_manifest_validation(
 
 
 @pytest.mark.parametrize("user_role", ["owner"])
-def test_post_new_job_invalid_items_spec(auth_client, user, db, dummy_job_plugin):
+def test_post_new_job_invalid_items_spec(
+    auth_client, user, db, dummy_job_plugin, mocker
+):
     # items_spec=None is not allowed for jobs
     # (but it works with actions)
     manifest = "quetz-dummyplugin:dummy_func"
+    dummy_func = mocker.Mock()
+    mocker.patch("quetz_dummyplugin.jobs.dummy_func", dummy_func, create=True)
     response = auth_client.post(
         "/api/jobs", json={"items_spec": None, "manifest": manifest}
     )

--- a/quetz/tests/test_jobs.py
+++ b/quetz/tests/test_jobs.py
@@ -244,7 +244,7 @@ async def test_running_task(db, user, package_version, supervisor):
     assert task.status == TaskStatus.pending
 
     # wait for task status to change
-    for i in range(50):
+    for i in range(100):
         time.sleep(0.05)
 
         db.refresh(task)
@@ -283,7 +283,7 @@ async def test_restart_worker_process(
     assert task.status == TaskStatus.pending
 
     # wait for task status to change
-    for i in range(50):
+    for i in range(100):
         time.sleep(0.05)
 
         db.refresh(task)

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -855,11 +855,11 @@ def test_wrong_package_format(client, dummy_repo, owner, job_supervisor):
     [
         ("proxy", None, "'mirror_channel_url' is undefined"),
         (None, "http://my-host", "'mirror_mode' is undefined"),
-        ("undefined", "http://my-host", "not a valid enumeration member"),
-        ("proxy", "my-host", "does not match"),
-        ("proxy", "http://", "does not match"),
-        ("proxy", "http:my-host", "does not match"),
-        ("proxy", "hosthttp://my-host", "does not match"),
+        ("undefined", "http://my-host", "Input should be 'proxy' or 'mirror'"),
+        ("proxy", "my-host", "String should match pattern"),
+        ("proxy", "http://", "String should match pattern"),
+        ("proxy", "http:my-host", "String should match pattern"),
+        ("proxy", "hosthttp://my-host", "String should match pattern"),
         (None, None, None),  # non-mirror channel
         ("proxy", "http://my-host", None),
         ("proxy", "https://my-host", None),

--- a/quetz/tests/test_mirror.py
+++ b/quetz/tests/test_mirror.py
@@ -1065,7 +1065,7 @@ def test_proxylist_mirror_channel(owner, client, mirror_mode):
 
     response = client.get(
         "/get/mirror-channel-btel/linux-64/nrnpython-0.1-0.tar.bz2",
-        allow_redirects=False,
+        follow_redirects=False,
     )
     assert response.status_code == 307
     assert (

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
   pluggy
   prometheus_client
   python-multipart
+  pydantic>=2.0.0
   pyyaml
   requests
   sqlalchemy


### PR DESCRIPTION
Migrate to Pydantic v2:

Had to force some fields to be `Optional` if they can be set to None.

- Ran [bump-pydantic](https://github.com/pydantic/bump-pydantic)
- Replace deprecated `parse_obj` and `from_orm` with `model_validate`
- Replace deprecated `dict` with `model_dump`
- Replace `update_forward_refs` with `model_rebuild`
- Remove `nullable=True` in pydantic Field. This isn't used. To mark a field as nullable, it should be set as Optional or "| None". Fix deprecation warning: Extra keyword arguments on `Field` is deprecated and will be removed.
- Add UserOptionalRole class. User role is nullable and should be optional in get (but not in set)
- Fix Job rest model. item_spec can't be set to required in JobBase and optional in Job (mypy complains). Create a new class JobCreate where item_spec is required. In job, item_spec is optional.
- Fix Packages and ChannelSearch rest models:
    - platforms is nullable: it should be optional
    - Channel description is optional - so should be ChannelSearch description

Fix #654 