### PR TITLE
Fix postgres pool size

### DIFF
--- a/quetz/deps.py
+++ b/quetz/deps.py
@@ -44,7 +44,14 @@ def get_config():
 
 def get_db(config: Config = Depends(get_config)):
     database_url = config.sqlalchemy_database_url
-    db = get_db_session(database_url, echo=config.sqlalchemy_echo_sql)
+    db = get_db_session(
+        database_url,
+        echo=config.sqlalchemy_echo_sql,
+        postgres_kwargs=dict(
+            pool_size=config.sqlalchemy_postgres_pool_size,
+            max_overflow=config.sqlalchemy_postgres_max_overflow,
+        ),
+    )
     try:
         yield db
     finally:


### PR DESCRIPTION
When having many requests in parallel, we got issue with the database connection pool size:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/20/3o7r)
```

According to the config, the default values should be 10 / 100. I found that postgres `pool_size` and `max_overflow` were passed when using `get_db_manager` but not in the `get_db` dependency.
Engine was created with the default values of 5 / 10, instead of the values from the config.