### PR TITLE
Fix docs rest model

### DIFF
--- a/quetz/rest_models.py
+++ b/quetz/rest_models.py
@@ -134,7 +134,7 @@ class ChannelMetadata(BaseModel):
 
 class Channel(ChannelBase):
     metadata: ChannelMetadata = Field(
-        default_factory=ChannelMetadata, title="channel metadata", examples={}
+        default_factory=ChannelMetadata, title="channel metadata", examples=[]
     )
 
     actions: Optional[List[ChannelActionEnum]] = Field(

--- a/quetz/tests/test_docs.py
+++ b/quetz/tests/test_docs.py
@@ -1,4 +1,16 @@
-def test_endpoint_docs(client):
+def test_docs_endpoint(client):
     response = client.get("/docs")
     assert response.status_code == 200
     assert "text/html" in response.headers['Content-Type']
+
+
+def test_openapi_endpoint(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert "text/json" in response.headers['Content-Type']
+
+
+def test_redoc_endpoint(client):
+    response = client.get("/redoc")
+    assert response.status_code == 200
+    assert "text/json" in response.headers['Content-Type']

--- a/quetz/tests/test_docs.py
+++ b/quetz/tests/test_docs.py
@@ -7,10 +7,10 @@ def test_docs_endpoint(client):
 def test_openapi_endpoint(client):
     response = client.get("/openapi.json")
     assert response.status_code == 200
-    assert "text/json" in response.headers['Content-Type']
+    assert "application/json" in response.headers['Content-Type']
 
 
 def test_redoc_endpoint(client):
     response = client.get("/redoc")
     assert response.status_code == 200
-    assert "text/json" in response.headers['Content-Type']
+    assert "text/html" in response.headers['Content-Type']

--- a/quetz/tests/test_docs.py
+++ b/quetz/tests/test_docs.py
@@ -1,0 +1,4 @@
+def test_endpoint_docs(client):
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert "text/html" in response.headers['Content-Type']


### PR DESCRIPTION
In the current branch, accessing the `/docs` endpoint raises the error at the bottom of this description. It looks like a result of the change to the pydantic version.

I've added a test to check if this works correctly, but this passes even if I don't add the fix. Could find any tests where we actually run the server first, is this something that should be added?

```
uetz-web         | INFO:     192.168.128.1:52674 - "GET /openapi.json HTTP/1.1" 500 Internal Server Error
quetz-web         | ERROR:    Exception in ASGI application
quetz-web         |   + Exception Group Traceback (most recent call last):
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 108, in __call__
quetz-web         |   |     response = await self.dispatch_func(request, call_next)
quetz-web         |   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |   |   File "/env/lib/python3.11/site-packages/quetz/main.py", line 159, in dispatch
quetz-web         |   |     response = await call_next(request)
quetz-web         |   |                ^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
quetz-web         |   |     raise app_exc
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
quetz-web         |   |     await self.app(scope, receive_or_disconnect, send_no_error)
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 106, in __call__
quetz-web         |   |     async with anyio.create_task_group() as task_group:
quetz-web         |   |   File "/env/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 664, in __aexit__
quetz-web         |   |     raise BaseExceptionGroup(
quetz-web         |   | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
quetz-web         |   +-+---------------- 1 ----------------
quetz-web         |     | Traceback (most recent call last):
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 108, in __call__
quetz-web         |     |     response = await self.dispatch_func(request, call_next)
quetz-web         |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/quetz/metrics/middleware.py", line 83, in dispatch
quetz-web         |     |     raise e from None
quetz-web         |     |   File "/env/lib/python3.11/site-packages/quetz/metrics/middleware.py", line 75, in dispatch
quetz-web         |     |     response = await call_next(request)
quetz-web         |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
quetz-web         |     |     raise app_exc
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
quetz-web         |     |     await self.app(scope, receive_or_disconnect, send_no_error)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/sessions.py", line 86, in __call__
quetz-web         |     |     await self.app(scope, receive, send_wrapper)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
quetz-web         |     |     raise exc
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
quetz-web         |     |     await self.app(scope, receive, sender)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
quetz-web         |     |     raise e
quetz-web         |     |   File "/env/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
quetz-web         |     |     await self.app(scope, receive, send)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
quetz-web         |     |     await route.handle(scope, receive, send)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
quetz-web         |     |     await self.app(scope, receive, send)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
quetz-web         |     |     response = await func(request)
quetz-web         |     |                ^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/fastapi/applications.py", line 247, in openapi
quetz-web         |     |     return JSONResponse(self.openapi())
quetz-web         |     |                         ^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/fastapi/applications.py", line 219, in openapi
quetz-web         |     |     self.openapi_schema = get_openapi(
quetz-web         |     |                           ^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/fastapi/openapi/utils.py", line 530, in get_openapi
quetz-web         |     |     return jsonable_encoder(OpenAPI(**output), by_alias=True, exclude_none=True)  # type: ignore
quetz-web         |     |                             ^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/pydantic/main.py", line 165, in __init__
quetz-web         |     |     __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
quetz-web         |     | pydantic_core._pydantic_core.ValidationError: 3 validation errors for OpenAPI
quetz-web         |     | components.schemas.Channel.Schema.properties.metadata.Schema.examples
quetz-web         |     |   Input should be a valid list [type=list_type, input_value={}, input_type=dict]
quetz-web         |     |     For further information visit https://errors.pydantic.dev/2.3/v/list_type
quetz-web         |     | components.schemas.Channel.Schema.properties.metadata.bool
quetz-web         |     |   Input should be a valid boolean [type=bool_type, input_value={'allOf': [{'$ref': '#/co...le': 'channel metadata'}, input_type=dict]
quetz-web         |     |     For further information visit https://errors.pydantic.dev/2.3/v/bool_type
quetz-web         |     | components.schemas.Channel.Reference.$ref
quetz-web         |     |   Field required [type=missing, input_value={'properties': {'name': {...nnel', 'type': 'object'}, input_type=dict]
quetz-web         |     |     For further information visit https://errors.pydantic.dev/2.3/v/missing
quetz-web         |     +------------------------------------
quetz-web         | 
quetz-web         | During handling of the above exception, another exception occurred:
quetz-web         | 
quetz-web         |   + Exception Group Traceback (most recent call last):
quetz-web         |   |   File "/env/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 408, in run_asgi
quetz-web         |   |     result = await app(  # type: ignore[func-returns-value]
quetz-web         |   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |   |   File "/env/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
quetz-web         |   |     return await self.app(scope, receive, send)
quetz-web         |   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |   |   File "/env/lib/python3.11/site-packages/fastapi/applications.py", line 292, in __call__
quetz-web         |   |     await super().__call__(scope, receive, send)
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
quetz-web         |   |     await self.middleware_stack(scope, receive, send)
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
quetz-web         |   |     raise exc
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
quetz-web         |   |     await self.app(scope, receive, _send)
quetz-web         |   |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 106, in __call__
quetz-web         |   |     async with anyio.create_task_group() as task_group:
quetz-web         |   |   File "/env/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 664, in __aexit__
quetz-web         |   |     raise BaseExceptionGroup(
quetz-web         |   | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
quetz-web         |   +-+---------------- 1 ----------------
quetz-web         |     | Traceback (most recent call last):
quetz-web         |     |   File "/env/lib/python3.11/site-packages/anyio/streams/memory.py", line 97, in receive
quetz-web         |     |     return self.receive_nowait()
quetz-web         |     |            ^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/anyio/streams/memory.py", line 92, in receive_nowait
quetz-web         |     |     raise WouldBlock
quetz-web         |     | anyio.WouldBlock
quetz-web         |     | 
quetz-web         |     | During handling of the above exception, another exception occurred:
quetz-web         |     | 
quetz-web         |     | Traceback (most recent call last):
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 78, in call_next
quetz-web         |     |     message = await recv_stream.receive()
quetz-web         |     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/anyio/streams/memory.py", line 112, in receive
quetz-web         |     |     raise EndOfStream
quetz-web         |     | anyio.EndOfStream
quetz-web         |     | 
quetz-web         |     | During handling of the above exception, another exception occurred:
quetz-web         |     | 
quetz-web         |     | Exception Group Traceback (most recent call last):
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 108, in __call__
quetz-web         |     |     response = await self.dispatch_func(request, call_next)
quetz-web         |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/quetz/main.py", line 159, in dispatch
quetz-web         |     |     response = await call_next(request)
quetz-web         |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
quetz-web         |     |     raise app_exc
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
quetz-web         |     |     await self.app(scope, receive_or_disconnect, send_no_error)
quetz-web         |     |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 106, in __call__
quetz-web         |     |     async with anyio.create_task_group() as task_group:
quetz-web         |     |   File "/env/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 664, in __aexit__
quetz-web         |     |     raise BaseExceptionGroup(
quetz-web         |     | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
quetz-web         |     +-+---------------- 1 ----------------
quetz-web         |       | Traceback (most recent call last):
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 108, in __call__
quetz-web         |       |     response = await self.dispatch_func(request, call_next)
quetz-web         |       |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/quetz/metrics/middleware.py", line 83, in dispatch
quetz-web         |       |     raise e from None
quetz-web         |       |   File "/env/lib/python3.11/site-packages/quetz/metrics/middleware.py", line 75, in dispatch
quetz-web         |       |     response = await call_next(request)
quetz-web         |       |                ^^^^^^^^^^^^^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
quetz-web         |       |     raise app_exc
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
quetz-web         |       |     await self.app(scope, receive_or_disconnect, send_no_error)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/sessions.py", line 86, in __call__
quetz-web         |       |     await self.app(scope, receive, send_wrapper)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
quetz-web         |       |     raise exc
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
quetz-web         |       |     await self.app(scope, receive, sender)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
quetz-web         |       |     raise e
quetz-web         |       |   File "/env/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
quetz-web         |       |     await self.app(scope, receive, send)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
quetz-web         |       |     await route.handle(scope, receive, send)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
quetz-web         |       |     await self.app(scope, receive, send)
quetz-web         |       |   File "/env/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
quetz-web         |       |     response = await func(request)
quetz-web         |       |                ^^^^^^^^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/fastapi/applications.py", line 247, in openapi
quetz-web         |       |     return JSONResponse(self.openapi())
quetz-web         |       |                         ^^^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/fastapi/applications.py", line 219, in openapi
quetz-web         |       |     self.openapi_schema = get_openapi(
quetz-web         |       |                           ^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/fastapi/openapi/utils.py", line 530, in get_openapi
quetz-web         |       |     return jsonable_encoder(OpenAPI(**output), by_alias=True, exclude_none=True)  # type: ignore
quetz-web         |       |                             ^^^^^^^^^^^^^^^^^
quetz-web         |       |   File "/env/lib/python3.11/site-packages/pydantic/main.py", line 165, in __init__
quetz-web         |       |     __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
quetz-web         |       | pydantic_core._pydantic_core.ValidationError: 3 validation errors for OpenAPI
quetz-web         |       | components.schemas.Channel.Schema.properties.metadata.Schema.examples
quetz-web         |       |   Input should be a valid list [type=list_type, input_value={}, input_type=dict]
quetz-web         |       |     For further information visit https://errors.pydantic.dev/2.3/v/list_type
quetz-web         |       | components.schemas.Channel.Schema.properties.metadata.bool
quetz-web         |       |   Input should be a valid boolean [type=bool_type, input_value={'allOf': [{'$ref': '#/co...le': 'channel metadata'}, input_type=dict]
quetz-web         |       |     For further information visit https://errors.pydantic.dev/2.3/v/bool_type
quetz-web         |       | components.schemas.Channel.Reference.$ref
quetz-web         |       |   Field required [type=missing, input_value={'properties': {'name': {...nnel', 'type': 'object'}, input_type=dict]
quetz-web         |       |     For further information visit https://errors.pydantic.dev/2.3/v/missing
quetz-web         |       +------------------------------------
```