### PR TITLE
add pam config section to config.py

### DIFF
--- a/quetz/authentication/pam.py
+++ b/quetz/authentication/pam.py
@@ -8,7 +8,7 @@ from fastapi import Request
 
 from quetz.authentication.base import BaseAuthenticator, FormHandlers, UserProfile
 from quetz.authorization import ServerRole
-from quetz.config import Config, ConfigEntry, ConfigSection
+from quetz.config import Config
 
 logger = logging.getLogger("quetz")
 
@@ -57,23 +57,6 @@ try:
         maintainer_groups: List[str] = []
         member_groups: List[str] = []
 
-        def _make_config(self):
-            section = ConfigSection(
-                "pamauthenticator",
-                [
-                    ConfigEntry("provider", str, default="pam", required=False),
-                    ConfigEntry("service", str, default="login", required=False),
-                    ConfigEntry("encoding", str, default="utf8", required=False),
-                    ConfigEntry("check_account", bool, default=True, required=False),
-                    ConfigEntry("admin_groups", list, default=list, required=False),
-                    ConfigEntry(
-                        "maintainer_groups", list, default=list, required=False
-                    ),
-                    ConfigEntry("member_groups", list, default=list, required=False),
-                ],
-            )
-            return [section]
-
         def _get_group_id_by_name(self, groupname):
             return grp.getgrnam(groupname).gr_gid
 
@@ -94,9 +77,6 @@ try:
             return os.getgrouplist(username, user_gid)
 
         def configure(self, config: Config):
-            config_options = self._make_config()
-            config.register(config_options)
-
             if config.configured_section("pamauthenticator"):
                 self.provider = config.pamauthenticator_provider
                 self.service = config.pamauthenticator_service

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -164,6 +164,19 @@ class Config:
             required=False,
         ),
         ConfigSection(
+            "pamauthenticator",
+            [
+                ConfigEntry("provider", str, default="pam", required=False),
+                ConfigEntry("service", str, default="login", required=False),
+                ConfigEntry("encoding", str, default="utf8", required=False),
+                ConfigEntry("check_account", bool, default=True, required=False),
+                ConfigEntry("admin_groups", list, default=list, required=False),
+                ConfigEntry("maintainer_groups", list, default=list, required=False),
+                ConfigEntry("member_groups", list, default=list, required=False),
+            ],
+            required=False,
+        ),
+        ConfigSection(
             "logging",
             [
                 ConfigEntry("level", str, default="INFO"),


### PR DESCRIPTION
I'm trying to get to a point where I can deploy quetz without using a config file. I'm currently trying to use the pam authenticator to do so, but ran into issues because the way quetz loads the config from the environment only works when the authenticator is known to the `Config.config_map`. This should fix that