### PR TITLE
Fix set user roles when role is None

### DIFF
--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -128,7 +128,7 @@ class Rules:
 
         return user_id
 
-    def assert_assign_user_role(self, role: str):
+    def assert_assign_user_role(self, role: Optional[str]):
         if role == SERVER_MAINTAINER or role == SERVER_OWNER:
             return self.assert_server_roles([SERVER_OWNER])
         if role == SERVER_MEMBER:

--- a/quetz/dao.py
+++ b/quetz/dao.py
@@ -240,7 +240,7 @@ class Dao:
         ).delete()
         self.db.commit()
 
-    def set_user_role(self, username: str, role: str):
+    def set_user_role(self, username: str, role: Optional[str]):
         user = self.db.query(User).filter(User.username == username).one_or_none()
 
         if user:

--- a/quetz/main.py
+++ b/quetz/main.py
@@ -499,7 +499,7 @@ def get_user_role(
 @api_router.put("/users/{username}/role", tags=["users"])
 def set_user_role(
     username: str,
-    role: rest_models.UserRole,
+    role: rest_models.UserOptionalRole,
     dao: Dao = Depends(get_dao),
     auth: authorization.Rules = Depends(get_rules),
 ):

--- a/quetz/tests/api/test_users.py
+++ b/quetz/tests/api/test_users.py
@@ -27,6 +27,7 @@ def test_validate_user_role_names(user, client, other_user, db):
         ("other", "owner", "member", 200),
         ("other", "owner", "maintainer", 200),
         ("other", "owner", "owner", 200),
+        ("other", "owner", None, 200),
         ("missing_user", "owner", "member", 404),
     ],
 )


### PR DESCRIPTION
The user role `None`, indicating that the user has no permissions on the server, was accidentally removed from the data model in https://github.com/mamba-org/quetz/pull/656. This PR brings it back.