### PR TITLE
Pin `typer` to address issues in argument defaults

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python>=3.7
   - pip
   - fastapi
-  - typer
+  - typer >=0.9,<1.0
   - authlib=0.15.5
   - psycopg2
   - httpx>=0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
   sqlalchemy-utils
   tenacity
   toml
-  typer
+  typer >=0.9,<1.0
   typing_extensions
   ujson
   uvicorn


### PR DESCRIPTION
## Motivation

The `typer` API has changed at some point. `v0.7.0` won't work anymore but it's the version installed on a fresh development environment.

See:
```bash
  File "<...>/quetz/cli.py", line 330, in <module>
    path: Annotated[str, typer.Argument(help="The path of the deployment")],
TypeError: Argument() missing 1 required positional argument: 'default'
```