### PR TITLE
Add google authentication proxy middleware

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   - mamba
   - conda-content-trust
   - pyinstrument
-  - pytest-asyncio 
+  - pytest-asyncio
   - pytest-timeout
   - pydantic >=2
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -42,14 +42,14 @@ dependencies:
   - adlfs
   - importlib_metadata
   - pre-commit
-  - pytest
+  - pytest 7.*
   - pytest-mock
   - rq
   - libcflib
   - mamba
   - conda-content-trust
   - pyinstrument
-  - pytest-asyncio
+  - pytest-asyncio 
   - pytest-timeout
   - pydantic >=2
   - pip:

--- a/plugins/quetz_googleiap/quetz_googleiap/middleware.py
+++ b/plugins/quetz_googleiap/quetz_googleiap/middleware.py
@@ -1,0 +1,114 @@
+import logging
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+import quetz.authentication.base as auth_base
+from quetz import rest_models
+from quetz.config import Config, ConfigEntry, ConfigSection
+from quetz.dao import Dao
+from quetz.deps import get_config, get_db
+
+logger = logging.getLogger("quetz.googleiam")
+
+
+def email_to_channel_name(email):
+    name = email.split("@")[0]
+    name = name.replace(".", "-")
+    name = name.replace("_", "-")
+    return name
+
+
+class GoogleIAMMiddleware(BaseHTTPMiddleware):
+    """
+    Handles Google IAM headers and authorizes users based on the
+    Google IAM headers.
+    """
+
+    def __init__(self, app, config: Config):
+        if config is not None:
+            self.configure(config)
+        self.last_checked = dict()
+        super().__init__(app)
+
+    def configure(self, config: Config):
+        config.register(
+            [
+                ConfigSection(
+                    "googleiam",
+                    [
+                        ConfigEntry("server_admin_emails", list, default=[]),
+                    ],
+                )
+            ]
+        )
+
+        # load configuration values
+        if config.configured_section("googleiam"):
+            self.server_admin_emails = config.googleiam_server_admin_emails
+        else:
+            raise Exception("Google IAM is not configured")
+
+    async def dispatch(self, request, call_next):
+        # Check if the session has a specific key, for example 'count'.
+        # If it does, increment its value. If it doesn't, set it to 1.
+        count = request.session.get("count", 0)
+        request.session["count"] = count + 1
+
+        db = next(get_db(get_config()))
+        dao = Dao(db)
+
+        user_id = request.headers.get("x-goog-authenticated-user-id")
+        email = request.headers.get("x-goog-authenticated-user-email")
+
+        if user_id and email:
+            _, email = email.split(":", 1)
+            _, user_id = user_id.split(":", 1)
+
+            user = dao.get_user_by_username(email)
+            if not user:
+                email_data: auth_base.Email = {
+                    "email": email,
+                    "verified": True,
+                    "primary": True,
+                }
+                user = dao.create_user_with_profile(
+                    email, "google", user_id, email, "", None, True, [email_data]
+                )
+            user_channel = email_to_channel_name(email)
+
+            logger.info(f"Creating channel for user: {user_channel}")
+            if dao.get_channel(email_to_channel_name(user_channel)) is None:
+                channel = rest_models.Channel(
+                    name=user_channel,
+                    private=False,
+                    description="Channel for user: " + email,
+                )
+                dao.create_channel(channel, user.id, "owner")
+
+            self.google_role_for_user(user_id, dao)
+
+            # we also need to find the role of the user
+            request.session['identity_provider'] = "dummy"
+            request.session["user_id"] = str(uuid.UUID(bytes=user.id))
+        else:
+            request.session["user_id"] = None
+            request.session["identity_provider"] = None
+
+        response = await call_next(request)
+        return response
+
+    def google_role_for_user(self, user_id, dao):
+        if not user_id:
+            return
+
+        if user_id in self.server_admin_emails:
+            logger.info(f"User {user_id} is server admin")
+            dao.set_user_role(user_id, "owner")
+        else:
+            logger.info(f"User {user_id} is not a server admin")
+            dao.set_user_role(user_id, "member")
+
+
+def middleware():
+    return GoogleIAMMiddleware

--- a/plugins/quetz_googleiap/quetz_googleiap/middleware.py
+++ b/plugins/quetz_googleiap/quetz_googleiap/middleware.py
@@ -91,7 +91,7 @@ class GoogleIAMMiddleware(BaseHTTPMiddleware):
                 )
                 dao.create_channel(channel, user.id, "owner")
 
-            self.google_role_for_user(user_id, dao)
+            self.google_role_for_user(user_id, email, dao)
             user_id = uuid.UUID(bytes=user.id)
             # drop the db and dao to remove the connection
             del db, dao
@@ -105,15 +105,17 @@ class GoogleIAMMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         return response
 
-    def google_role_for_user(self, user_id, dao):
-        if not user_id:
+    def google_role_for_user(self, user_id, username, dao):
+        if not user_id or not username:
             return
 
-        if user_id in self.server_admin_emails:
-            logger.info(f"User {user_id} is server admin")
+        if username in self.server_admin_emails:
+            logger.info(f"User '{username}' with user id '{user_id}' is server admin")
             dao.set_user_role(user_id, "owner")
         else:
-            logger.info(f"User {user_id} is not a server admin")
+            logger.info(
+                f"User '{username}' with user id '{user_id}' is not a server admin"
+            )
             dao.set_user_role(user_id, "member")
 
 

--- a/plugins/quetz_googleiap/quetz_googleiap/middleware.py
+++ b/plugins/quetz_googleiap/quetz_googleiap/middleware.py
@@ -56,7 +56,7 @@ class GoogleIAMMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request, call_next):
         # ignore middleware if it is not configured
-        if not self.configured:
+        if not self.configured or request.url.path.startswith("/health"):
             response = await call_next(request)
             return response
 

--- a/plugins/quetz_googleiap/quetz_googleiap/middleware.py
+++ b/plugins/quetz_googleiap/quetz_googleiap/middleware.py
@@ -60,11 +60,6 @@ class GoogleIAMMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
             return response
 
-        # Check if the session has a specific key, for example 'count'.
-        # If it does, increment its value. If it doesn't, set it to 1.
-        count = request.session.get("count", 0)
-        request.session["count"] = count + 1
-
         user_id = request.headers.get("x-goog-authenticated-user-id")
         email = request.headers.get("x-goog-authenticated-user-email")
 

--- a/plugins/quetz_googleiap/setup.py
+++ b/plugins/quetz_googleiap/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+
+plugin_name = "quetz-googleiap"
+
+setup(
+    name=plugin_name,
+    install_requires=[],
+    entry_points={
+        "quetz.middlewares": [f"{plugin_name} = quetz_googleiap.middleware"],
+    },
+    packages=[
+        "quetz_googleiap",
+    ],
+)

--- a/plugins/quetz_googleiap/tests/conftest.py
+++ b/plugins/quetz_googleiap/tests/conftest.py
@@ -8,6 +8,7 @@ def plugins():
     # defines plugins to enable for testing
     return ['quetz-googleiap']
 
+
 @pytest.fixture
 def sqlite_in_memory():
     # use sqlite on disk so that we can modify it in a different process

--- a/plugins/quetz_googleiap/tests/conftest.py
+++ b/plugins/quetz_googleiap/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytest_plugins = "quetz.testing.fixtures"
+
+
+@pytest.fixture
+def plugins():
+    # defines plugins to enable for testing
+    return ['quetz-googleiap']
+
+@pytest.fixture
+def sqlite_in_memory():
+    # use sqlite on disk so that we can modify it in a different process
+    return False

--- a/plugins/quetz_googleiap/tests/test_googleiap.py
+++ b/plugins/quetz_googleiap/tests/test_googleiap.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "config_extra", ['[googleiam]\nserver_admin_emails=["test@tester.com"]']
+)
+def test_authentication(client, db):
+    response = client.get("/api/me")
+    assert response.status_code == 401
+
+    # add headers
+    headers = {
+        'X-Goog-Authenticated-User-Email': 'accounts.google.com:someone@tester.com',
+        'X-Goog-Authenticated-User-Id': 'accounts.google.com:someone@tester.com',
+    }
+
+    response = client.get("/api/me", headers=headers)
+    assert response.status_code == 200
+
+    # # check if channel was created
+    # response = client.get("/api/channels", headers=headers)
+    # assert response.status_code == 200
+    # assert response.json()['channels'][0]['name'] == 'someone'

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ dev =
   flake8
   isort
   pre-commit
-  pytest
+  pytest >=7,<8
   pytest-asyncio
   pytest-mock
   pytest-cov


### PR DESCRIPTION
This adds a new plugin and hook for middlewares (added by plugins).

The middleware uses the headers from Google's Identity Aware Proxy to authenticate users. Furthermore, it "magically" creates a public channel per user and gives a list of pre-configured user server-owner (admin) status.