### PR TITLE
feat: Support pre-configured supertoken authentication

### DIFF
--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -70,7 +70,7 @@ Configure default user permissions, creating default channel and super-admin per
    [users]
    # an optional supertoken that can be used to bypass authorization
    # e.g. for CI pipelines that need to rely on pre-configured tokens for the initial
-   # technial superuser. Length should be at least 32 characters.
+   # technial superuser. Length must be at least 32 characters.
    supertoken = "use `openssl rand -hex 32` to generate a random token"
    # users with owner role
    admins = ["github:admin_user"]

--- a/docs/source/deploying/configuration.rst
+++ b/docs/source/deploying/configuration.rst
@@ -68,6 +68,10 @@ Configure default user permissions, creating default channel and super-admin per
 .. code::
 
    [users]
+   # an optional supertoken that can be used to bypass authorization
+   # e.g. for CI pipelines that need to rely on pre-configured tokens for the initial
+   # technial superuser. Length should be at least 32 characters.
+   supertoken = "use `openssl rand -hex 32` to generate a random token"
    # users with owner role
    admins = ["github:admin_user"]
    # users with maintainer role

--- a/quetz/authorization.py
+++ b/quetz/authorization.py
@@ -60,13 +60,17 @@ class Rules:
                     detail="Supertoken too short, must be at least 32 characters long",
                 )
             self.API_key = None
-            self.is_supertoken = True
+            self._is_supertoken = True
         else:
             self.API_key = API_key
-            self.is_supertoken = False
+            self._is_supertoken = False
 
         self.session = session
         self.db = db
+
+    @property
+    def is_supertoken(self) -> bool:
+        return self._is_supertoken
 
     def get_valid_api_key(self) -> Optional[ApiKey]:
         if not self.API_key:

--- a/quetz/config.py
+++ b/quetz/config.py
@@ -175,6 +175,7 @@ class Config:
         ConfigSection(
             "users",
             [
+                ConfigEntry("supertoken", str, default=None, required=False),
                 ConfigEntry("admins", list, default=list),
                 ConfigEntry("maintainers", list, default=list),
                 ConfigEntry("members", list, default=list),
@@ -494,6 +495,16 @@ class Config:
                     'redirect_expiration': int(self.local_store_redirect_expiration),
                 }
             )
+
+    def get_supertoken(self) -> Optional[str]:
+        """Return the super token if it is set in the config.
+
+        Returns
+        -------
+        supertoken : Optional[str]
+            The super token
+        """
+        return self.config.get("users", {}).get("supertoken")
 
     def configured_section(self, section: str) -> bool:
         """Return if a given section has been configured.

--- a/quetz/deps.py
+++ b/quetz/deps.py
@@ -84,8 +84,14 @@ def get_rules(
     request: Request,
     session: dict = Depends(get_session),
     db: Session = Depends(get_db),
+    config: Config = Depends(get_config),
 ):
-    return authorization.Rules(request.headers.get("x-api-key"), session, db)
+    return authorization.Rules(
+        request.headers.get("x-api-key"),
+        session,
+        db,
+        supertoken=config.get_supertoken(),
+    )
 
 
 def get_tasks_worker(

--- a/quetz/tasks/workers.py
+++ b/quetz/tasks/workers.py
@@ -178,7 +178,12 @@ def job_wrapper(
         api_key = None
         if user_id:
             browser_session['user_id'] = user_id
-        auth = Rules(api_key, browser_session, db)
+        auth = Rules(
+            api_key,
+            browser_session,
+            db,
+            supertoken=config.get_supertoken(),
+        )
     if not session:
         session = get_remote_session()
 


### PR DESCRIPTION
# Motivation

We want to run automated CI tests on a dockerized version of quetz (deployed with helm/Kubernetes). To be able to use the API there without any real user (e.g. authenticated via GitHub) we would like to be able to define a supertoken in the TOML config. It should act as an initial technical service account.
This token does not have to support all API endpoints (that could depend on an actual user being present). However, it should at least support creating new "real users"  with username/password authentication (in our case https://github.com/mamba-org/quetz-sql-authenticator).

# Changes

Introduce a new config element `users.supertoken` and allow the `Rules` class to bypass this token in the server role assertions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206579607918088