### PR TITLE
Import _build_current_repodata from conda_index instead of conda_build

### DIFF
--- a/plugins/quetz_current_repodata/quetz_current_repodata/main.py
+++ b/plugins/quetz_current_repodata/quetz_current_repodata/main.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from conda_build.index import _build_current_repodata
+from conda_index.index import _build_current_repodata
 
 import quetz
 from quetz.utils import add_temp_static_file


### PR DESCRIPTION
Importing  `_build_current_repodata` has been deprecated in `conda_build`: https://github.com/search?q=repo%3Aconda%2Fconda-build%20_build_current_repodata&type=code

This PR uses the new `conda_index` module for importing `_build_current_repodata`  instead of the deprecated functionality in `conda_build` . 