### PR TITLE
update docker compose configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
     bzip2 \
     ca-certificates \
     curl \
+    git \
     postgresql-client \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 RUN curl -L https://micro.mamba.pm/api/micromamba/linux-64/latest | \

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -572,7 +572,7 @@ c.JupyterHub.services = [
         "url": "http://web:8000",
         # any secret >8 characters, you'll use api_token to
         # authenticate api requests to the hub from your service
-        "oauth_client_id": "quetz_client",
+        "oauth_client_id": "service-quetz-client",
         "oauth_redirect_uri": "http://localhost:8000/auth/jupyterhub/authorize",
         "api_token": "super-secret",
     }


### PR DESCRIPTION
This PR includes two small fixes to make the quetz docker compose configuration work again:

- Add git to the Docker image allowing micromamba to install the `git+https://github.com/jupyter-server/jupyter_releaser.git@v2` requirement from `environment.yaml`
- Rename the `oauth_client_id` to `service-quetz-client` according to the new oauth service naming requirements