### PR TITLE
fix: Include '.conda' packages for reindexing from package store

### DIFF
--- a/plugins/quetz_mamba_solve/conda-requirements.txt
+++ b/plugins/quetz_mamba_solve/conda-requirements.txt
@@ -1,2 +1,2 @@
 mamba
-conda-build >=3.20
+conda-build >=3.20,<24.7.0

--- a/quetz/tasks/reindexing.py
+++ b/quetz/tasks/reindexing.py
@@ -137,7 +137,7 @@ def reindex_packages_from_store(
     user_id = uuid_to_bytes(user_id)
     pkgstore = config.get_package_store()
     all_files = pkgstore.list_files(channel_name)
-    pkg_files = [f for f in all_files if f.endswith(".tar.bz2")]
+    pkg_files = [f for f in all_files if f.endswith((".tar.bz2", ".conda"))]
     nthreads = config.general_package_unpack_threads
 
     logger.debug(f"Found {len(pkg_db)} packages for channel {channel_name} in database")


### PR DESCRIPTION
Currently only `.tar.bz2` packages are considered for reindexing. This PR will allow reindexing to see `.conda` packages too.

fixes #703 