### PR TITLE
Update actions/upload-artifact@v1 to v4 in sphinx.yml

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd docs
           make html SPHINXOPTS="-W"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         name: "upload artifacts"
         with:
           name: DocumentationHTML


### PR DESCRIPTION
This action was [deprecated in June](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).